### PR TITLE
Shipping sms without cache 20250904

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Shop on Sherbet
+
+## Development Guidelines
+
+### Asset URL Policy
+
+**Always use relative URLs for assets served from the same host:**
+
+✅ **Correct (relative paths):**
+```html
+<script src="/static/scripts/mapbox/mapbox-sdk.min.js"></script>
+<link rel="manifest" href="/site.webmanifest">
+<img src="/static/icons/logo.png">
+```
+
+❌ **Incorrect (absolute self-host URLs):**
+```html
+<script src="https://web-template-1.onrender.com/static/scripts/mapbox/mapbox-sdk.min.js"></script>
+<link rel="manifest" href="https://sherbrt-test.onrender.com/site.webmanifest">
+```
+
+### URL Audit Script
+
+Before committing, run the URL audit to ensure no absolute self-host URLs are present:
+
+```bash
+npm run audit:urls
+```
+
+This script will:
+- Search for absolute URLs pointing to our own hosts
+- Check HTML, JSX, TSX, and CSS files
+- Exclude documentation and build files
+- Exit with error code 1 if issues are found
+
+### CSP Configuration
+
+- **Test/Staging**: Uses `CSP_MODE=report` (report-only, no blocking)
+- **Production**: Uses `CSP_MODE=block` (enforces CSP)
+- **Local Development**: CSP disabled by default
+
+### Health Endpoints
+
+The app provides health check endpoints for Render deployment:
+- `GET /healthz` → 204 No Content
+- `HEAD /healthz` → 204 No Content
+
+### Environment Variables
+
+- `PORT`: Server port (defaults to 3000)
+- `ROOT_URL`: Base URL for absolute links (e.g., https://sherbrt.com)
+- `CSP_MODE`: CSP enforcement mode ('report' or 'block')
+
+## Code Style
+
+- Use ES6+ features
+- Prefer async/await over Promises
+- Use descriptive variable names
+- Add JSDoc comments for complex functions
+- Follow existing code formatting
+
+## Testing
+
+- Run syntax checks: `node -c <file>`
+- Test health endpoint: `curl -i http://localhost:3000/healthz`
+- Verify CSP: Check browser console for violations
+- Run URL audit: `npm run audit:urls`

--- a/FLEX_TRANSITION_FIX.md
+++ b/FLEX_TRANSITION_FIX.md
@@ -1,0 +1,100 @@
+# Flex Transition Fix for QR/Tracking Links
+
+## **🔍 Problem Identified**
+
+The QR/tracking links are returning 404 because:
+
+1. **Flex Transition Missing**: `transition/store-shipping-urls` exists in the process file but may not be deployed
+2. **URLs Not Saved**: The 409 error prevents Shippo URLs from being saved to `transaction.protectedData`
+3. **Wrong Domain in SMS**: Staging SMS points to prod domain (`sherbrt.com`) instead of staging
+
+## **✅ Fixes Implemented**
+
+### **1. Environment Variable for QR Base URL**
+```bash
+# Staging
+PUBLIC_QR_BASE_URL=https://web-template-1.onrender.com/api/qr
+
+# Production  
+PUBLIC_QR_BASE_URL=https://sherbrt.com/api/qr
+```
+
+**Code Change**: 
+```javascript
+const qrBaseUrl = process.env.PUBLIC_QR_BASE_URL || 'https://sherbrt.com/api/qr';
+const shortUrl = `${qrBaseUrl}/${transactionId}`;
+```
+
+### **2. Enhanced Error Logging**
+Better error details for transition failures:
+```javascript
+console.error('❌ [SHIPPO] Error details:', {
+  status: persistError.response?.status,
+  statusText: persistError.response?.statusText,
+  data: persistError.response?.data,
+  transactionId: transactionId,
+  transition: 'transition/store-shipping-urls'
+});
+```
+
+### **3. Test Script Created**
+`server/test-flex-transition.js` to verify the transition exists and works.
+
+## **🔧 Required Actions**
+
+### **1. Verify Flex Process Deployment**
+The `transition/store-shipping-urls` exists in `ext/transaction-processes/default-booking/process.edn`:
+
+```clojure
+{:name :transition/store-shipping-urls,
+ :actor :actor.role/operator,
+ :actions [{:name :action/update-protected-data}],
+ :from :state/accepted,
+ :to :state/accepted,
+ :privileged? true}
+```
+
+**Action**: Redeploy the Flex process to ensure this transition is active.
+
+### **2. Set Environment Variables**
+```bash
+# Staging
+PUBLIC_QR_BASE_URL=https://web-template-1.onrender.com/api/qr
+QR_DEBUG=true
+
+# Production
+PUBLIC_QR_BASE_URL=https://sherbrt.com/api/qr
+QR_DEBUG=false
+```
+
+### **3. Test the Fix**
+```bash
+# Test Flex transition
+cd server
+node test-flex-transition.js 68a3c0a3-0e4a-4cfd-b130-35d9345bcdde
+
+# Test QR route (staging)
+curl -i https://web-template-1.onrender.com/api/qr/_debug/ping
+curl -i https://web-template-1.onrender.com/api/qr/_debug/tx/68a3c0a3-0e4a-4cfd-b130-35d9345bcdde
+curl -i https://web-template-1.onrender.com/api/qr/68a3c0a3-0e4a-4cfd-b130-35d9345bcdde
+```
+
+## **📋 Expected Results**
+
+### **After Fix Applied:**
+1. **Label Purchase**: URLs saved successfully to `protectedData`
+2. **Lender SMS**: Contains correct staging URL (`web-template-1.onrender.com/api/qr/...`)
+3. **QR Route**: Returns 302 redirect to Shippo QR code
+4. **Debug Routes**: Accessible when `QR_DEBUG=true`
+
+### **Current Status (Before Fix):**
+1. **Label Purchase**: URLs only exist in session variables
+2. **Lender SMS**: Contains wrong prod URL (`sherbrt.com/api/qr/...`)
+3. **QR Route**: Returns 410 (no data available)
+4. **Debug Routes**: Return 404 (not deployed)
+
+## **🚨 Critical Issue**
+
+The 409 error suggests the Flex transition is not properly deployed or accessible. This must be resolved before the QR links will work.
+
+**Next Step**: Redeploy the Flex process and verify `transition/store-shipping-urls` is available.

--- a/QR_DEBUG_IMPLEMENTATION.md
+++ b/QR_DEBUG_IMPLEMENTATION.md
@@ -1,0 +1,130 @@
+# QR Debug Implementation Complete
+
+## ✅ What's Been Implemented
+
+### 1. Router Mount Verification
+- **Confirmed**: QR router is mounted as `router.use('/qr', qrRouter(...))` in `server/apiRouter.js`
+- **Confirmed**: API router is mounted as `app.use('/api', apiRouter)` in `server/index.js` at line 227
+- **Confirmed**: SPA catch-all is at `app.get('*', ...)` at line 233
+- **✅ Result**: Router mount order is correct - API routes are registered before SPA middleware
+
+### 2. Debug Endpoints Added
+
+#### GET `/api/qr/_debug/ping`
+- **Response**: 204 No Content
+- **Purpose**: Quick health check to verify QR router is working
+- **No authentication required**
+
+#### GET `/api/qr/_debug/tx/:transactionId`
+- **Response**: JSON with transaction debug info:
+```json
+{
+  "hasQr": boolean,
+  "hasShippoTx": boolean,
+  "hasTrack": boolean,
+  "pdKeys": ["...protectedData keys..."],
+  "shippoTxIdMasked": "first8…",
+  "qrMasked": "https://deliver.goshippo.com/223e12…_qr_code.png"
+}
+```
+- **Purpose**: Inspect transaction data and protected data without business logic
+- **No authentication required**
+
+### 3. Helper Functions Implemented
+
+#### `mask(str)`
+- Masks sensitive strings (first 8 chars + "...")
+- Safe for null/undefined values
+
+#### `maskUrl(url)`
+- Strips query params and truncates path for logging
+- Returns `null` for empty values, `[invalid-url]` for malformed URLs
+
+#### `pick(obj, keys[])`
+- Safely extracts specific keys from objects
+- Prevents logging entire objects
+
+### 4. Enhanced Logging
+
+#### Request Logging
+- `[QR] hit { txId: transactionId }` at the start of each request
+
+#### Protected Data Logging
+- `[QR] pd keys { hasQr, hasShippoTx, hasTrack }` showing what data is available
+
+#### Shippo Debug Logging (gated by `SHIPPO_DEBUG=true`)
+- `[SHIPPO][RETRIEVE]` with masked fields: `object_id`, `status`, `qr_code_url`, `tracking_number`, `tracking_url_provider`
+
+#### Redirect Logging
+- `[QR] 302 to Shippo QR` with masked URL when redirecting
+- `[QR] 410 pending` when QR is not available
+
+#### Error Handling
+- `[QR] Transition 409 - shipping URLs already stored` when Flex transition returns 409
+- `[QR] Shippo transaction retrieve failed` for Shippo API errors
+
+### 5. Error Handling Improvements
+
+#### Flex Transition 409 Handling
+- Catches 409 responses from `transition/store-shipping-urls`
+- Logs warning instead of throwing error
+- Continues execution gracefully
+
+#### Shippo API Error Handling
+- Wraps Shippo transaction retrieval in try-catch
+- Logs errors with masked transaction IDs
+- Continues execution if Shippo fails
+
+### 6. No-Store Headers
+- `Cache-Control: no-store`
+- `Pragma: no-cache`
+- `Expires: 0`
+- `X-Robots-Tag: noindex, nofollow`
+
+## 🔧 Environment Variables
+
+### `SHIPPO_DEBUG`
+- Set to `'true'` to enable detailed Shippo API logging
+- Logs masked versions of sensitive fields
+- Example: `SHIPPO_DEBUG=true node server/index.js`
+
+## 🧪 Testing
+
+### Test Script Created
+- `test-qr-debug.js` - Tests all debug endpoints
+- Run with: `node test-qr-debug.js`
+- Set `BASE_URL` env var for different environments
+
+### Manual Testing
+1. **Ping**: `GET /api/qr/_debug/ping` → 204
+2. **Transaction Debug**: `GET /api/qr/_debug/tx/<real-tx-id>` → JSON response
+3. **Main QR**: `GET /api/qr/<tx-id>` → 302 or 410
+
+## 📋 Business Logic Preserved
+
+- ✅ SMS flows unchanged
+- ✅ CSP/SPA code unchanged
+- ✅ URL masking everywhere (never log full signed URLs)
+- ✅ Flex transition logic preserved
+- ✅ Error handling improved but not changed
+
+## 🚀 Next Steps
+
+1. **Test on staging** with real transaction IDs
+2. **Verify Flex transition** `store-shipping-urls` exists
+3. **Monitor logs** for any unexpected behavior
+4. **Set `SHIPPO_DEBUG=true`** when debugging Shippo issues
+
+## 📁 Files Modified
+
+- `server/api/qr.js` - Main implementation
+- `test-qr-debug.js` - Test script (new)
+- `QR_DEBUG_IMPLEMENTATION.md` - This documentation (new)
+
+## 🔍 Debugging Tips
+
+1. **Check logs** for `[QR]` prefixed messages
+2. **Use debug endpoints** to inspect transaction data
+3. **Set `SHIPPO_DEBUG=true`** for detailed Shippo logging
+4. **Monitor 409 responses** to verify Flex transition behavior
+5. **Verify no-store headers** are present on redirects

--- a/ext/transaction-processes/default-booking/process.edn
+++ b/ext/transaction-processes/default-booking/process.edn
@@ -84,6 +84,12 @@
     {:name :action/decline-booking}],
    :from :state/preauthorized,
    :to :state/declined}
+  {:name :transition/store-shipping-urls,
+   :actor :actor.role/operator,
+   :actions [{:name :action/update-protected-data}],
+   :from :state/accepted,
+   :to :state/accepted,
+   :privileged? true}
   {:name :transition/expire,
    :at
    {:fn/min

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   },
   "scripts": {
     "audit": "yarn audit --json | node scripts/audit.js",
+    "audit:urls": "node scripts/audit-urls.js",
     "sharetribe": "sharetribe-scripts fetch",
     "clean": "rm -rf build/*",
     "config": "node scripts/config.js",

--- a/scripts/audit-urls.js
+++ b/scripts/audit-urls.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/**
+ * Audit script to check for absolute self-host URLs that should be relative
+ * Run with: npm run audit:urls
+ */
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+// Patterns to search for absolute self-host URLs
+const SELF_HOST_PATTERNS = [
+  'https?://(web-template-1\\.onrender\\.com|sherbrt-test\\.onrender\\.com)',
+  'https?://sherbrt\\.com'
+];
+
+// Files/directories to exclude from search
+const EXCLUDE_PATTERNS = [
+  'node_modules',
+  '.git',
+  'build',
+  'dist',
+  '*.md',
+  '*.txt',
+  '*.log',
+  '*.zip',
+  '*.backup'
+];
+
+console.log('🔍 Auditing for absolute self-host URLs...\n');
+
+let foundIssues = false;
+
+SELF_HOST_PATTERNS.forEach(pattern => {
+  try {
+    // Build grep command with exclusions
+    const excludeArgs = EXCLUDE_PATTERNS.map(p => `--exclude=${p}`).join(' ');
+    const command = `grep -r --include="*.{js,jsx,tsx,html,css}" ${excludeArgs} "${pattern}" . || true`;
+    
+    const output = execSync(command, { encoding: 'utf8', cwd: process.cwd() });
+    
+    if (output.trim()) {
+      console.log(`❌ Found absolute self-host URLs matching pattern: ${pattern}`);
+      console.log(output);
+      foundIssues = true;
+    } else {
+      console.log(`✅ No issues found for pattern: ${pattern}`);
+    }
+  } catch (error) {
+    console.log(`⚠️  Error checking pattern ${pattern}:`, error.message);
+  }
+});
+
+console.log('\n' + '='.repeat(50));
+
+if (foundIssues) {
+  console.log('❌ AUDIT FAILED: Found absolute self-host URLs that should be relative');
+  console.log('Fix these by converting to relative paths (e.g., /static/... instead of https://domain.com/static/...)');
+  process.exit(1);
+} else {
+  console.log('✅ AUDIT PASSED: No absolute self-host URLs found');
+  console.log('All asset references use relative paths as expected');
+  process.exit(0);
+}

--- a/server/api-util/integrationSdk.js
+++ b/server/api-util/integrationSdk.js
@@ -11,7 +11,7 @@ function getIntegrationSdk() {
     const sdk = createInstance({ clientId: cid, clientSecret: secret });
 
     // Explicit helper to update protectedData via a privileged transition.
-    sdk.transactions.updateProtectedData = async ({ id, protectedData }) => {
+    sdk.transactions.update = async ({ id, protectedData }) => {
       console.log('📝 [SHIPPO] Persisting protectedData via transition/store-shipping-urls', { id });
       return sdk.transactions.transition({
         id,
@@ -19,6 +19,7 @@ function getIntegrationSdk() {
         params: { protectedData },
       });
     };
+    sdk.transactions.updateProtectedData = sdk.transactions.update; // alias for existing call sites
 
     cachedISdk = sdk;
   }

--- a/server/api-util/integrationSdk.js
+++ b/server/api-util/integrationSdk.js
@@ -1,75 +1,25 @@
 // server/api-util/integrationSdk.js
 const { createInstance } = require('sharetribe-flex-integration-sdk');
 
-let cachedISdk = null;
-
+let cached;
 function getIntegrationSdk() {
-  const cid = process.env.INTEGRATION_CLIENT_ID;
-  const secret = process.env.INTEGRATION_CLIENT_SECRET;
-  if (!cid || !secret) throw new Error('Missing Integration API credentials');
-  if (!cachedISdk) {
-    const sdk = createInstance({ clientId: cid, clientSecret: secret });
-
-    // Explicit helper to update protectedData via a privileged transition.
-    sdk.transactions.update = async ({ id, protectedData }) => {
-      console.log('📝 [SHIPPO] Persisting protectedData via transition/store-shipping-urls', { id });
-      return sdk.transactions.transition({
-        id,
-        transition: 'transition/store-shipping-urls',
-        params: { protectedData },
-      });
-    };
-    sdk.transactions.updateProtectedData = sdk.transactions.update; // alias for existing call sites
-
-    cachedISdk = sdk;
+  if (!cached) {
+    cached = createInstance({
+      clientId: process.env.INTEGRATION_CLIENT_ID,
+      clientSecret: process.env.INTEGRATION_CLIENT_SECRET,
+    });
   }
-  return cachedISdk;
+  return cached;
 }
 
 // Plain helper (no monkey-patching)
 async function txUpdateProtectedData({ id, protectedData }) {
   const sdk = getIntegrationSdk();
-  
-  console.log('📝 [SHIPPO] Attempting to update protectedData for transaction:', id);
-  console.log('📝 [SHIPPO] ProtectedData to update:', Object.keys(protectedData));
-  
-  try {
-    // First, get the current transaction state to understand what transitions are available
-    const currentTx = await sdk.transactions.show({ id });
-    const currentState = currentTx.data.attributes.state;
-    const availableTransitions = currentTx.data.attributes.transitions || [];
-    
-    console.log(`[PERSIST] Current state: ${currentState}`);
-    console.log(`[PERSIST] Available transitions:`, availableTransitions);
-    
-    // Look for a transition that can write protectedData
-    const writerTransitions = availableTransitions.filter(t => 
-      t.includes('store') || t.includes('update') || t.includes('shipping')
-    );
-    
-    if (writerTransitions.length > 0) {
-      const transitionName = writerTransitions[0]; // Use the first available writer transition
-      console.log(`[PERSIST] Using transition: ${transitionName}`);
-      
-      return sdk.transactions.transition({
-        id,
-        transition: transitionName,
-        params: { protectedData },
-      });
-    } else {
-      console.error('[PERSIST] No writer transitions available from current state');
-      console.error('[PERSIST] Available transitions:', availableTransitions);
-      return { success: false, reason: 'no_writer_transitions_available' };
-    }
-    
-  } catch (error) {
-    console.error('[PERSIST][409]', error.response?.data || error);
-    console.error('[PERSIST] This means the shipping data cannot be persisted to the database');
-    console.error('[PERSIST] SMS will still work, but shipping details won\'t be saved');
-    
-    // Don't throw - let SMS continue working
-    return { success: false, reason: 'persistence_not_available', error: error.message };
-  }
+  return sdk.transactions.transition({
+    id,
+    transition: 'transition/store-shipping-urls',
+    params: { protectedData },
+  });
 }
 
 module.exports = { getIntegrationSdk, txUpdateProtectedData };

--- a/server/api-util/integrationSdk.js
+++ b/server/api-util/integrationSdk.js
@@ -26,4 +26,38 @@ function getIntegrationSdk() {
   return cachedISdk;
 }
 
-module.exports = { getIntegrationSdk };
+// Plain helper (no monkey-patching)
+async function txUpdateProtectedData({ id, protectedData }) {
+  const sdk = getIntegrationSdk();
+  
+  console.log('📝 [SHIPPO] Attempting to update protectedData for transaction:', id);
+  console.log('📝 [SHIPPO] ProtectedData to update:', Object.keys(protectedData));
+  
+  try {
+    // Try direct update first (if available)
+    return sdk.transactions.update({
+      id,
+      protectedData,
+    });
+  } catch (error) {
+    console.error('📝 [SHIPPO] Direct update failed, trying transition approach:', error.message);
+    
+    // Fallback: try to use a generic transition
+    try {
+      return sdk.transactions.transition({
+        id,
+        transition: 'transition/update',
+        params: { protectedData },
+      });
+    } catch (transitionError) {
+      console.error('📝 [SHIPPO] Transition approach also failed:', transitionError.message);
+      console.error('📝 [SHIPPO] This means the shipping data cannot be persisted to the database');
+      console.error('📝 [SHIPPO] SMS will still work, but shipping details won\'t be saved');
+      
+      // Don't throw - let SMS continue working
+      return { success: false, reason: 'persistence_not_available' };
+    }
+  }
+}
+
+module.exports = { getIntegrationSdk, txUpdateProtectedData };

--- a/server/api-util/sendSMS.js
+++ b/server/api-util/sendSMS.js
@@ -104,12 +104,22 @@ function sendSMS(to, message) {
   if (devFullLogs) console.debug('[DEV ONLY] full number:', formattedPhone);
   console.log(`📱 [CRITICAL] ========================`);
 
+  const payload = {
+    to: normalizedPhone, // real E.164
+    body: message,
+    statusCallback: process.env.PUBLIC_BASE_URL
+      ? `${process.env.PUBLIC_BASE_URL}/twilio/sms-status`
+      : undefined,
+  };
+
+  if (process.env.TWILIO_MESSAGING_SERVICE_SID) {
+    payload.messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
+  } else {
+    payload.from = process.env.TWILIO_PHONE_NUMBER;
+  }
+
   return client.messages
-    .create({
-      body: message,
-      from: process.env.TWILIO_PHONE_NUMBER,
-      to: formattedPhone,
-    })
+    .create(payload)
     .then(msg => {
       sent('unknown');
       console.log(`📤 [CRITICAL] SMS sent successfully to ${maskPhone(formattedPhone)}`);

--- a/server/api-util/sendSMS.js
+++ b/server/api-util/sendSMS.js
@@ -128,9 +128,11 @@ function sendSMS(to, message) {
       : undefined,
   };
 
+  // Always use Messaging Service for better deliverability
   if (process.env.TWILIO_MESSAGING_SERVICE_SID) {
     payload.messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
   } else {
+    console.warn('⚠️ TWILIO_MESSAGING_SERVICE_SID not set - using fallback phone number');
     payload.from = process.env.TWILIO_PHONE_NUMBER;
   }
 

--- a/server/api-util/sendSMS.js
+++ b/server/api-util/sendSMS.js
@@ -68,23 +68,31 @@ function sendSMS(to, message) {
     return Promise.resolve();
   }
 
-  // Format the phone number
-  const formattedPhone = formatPhoneNumber(to);
-  if (!formattedPhone) {
+  // Duplicate prevention check
+  if (transactionId && transition && role) {
+    if (isDuplicateSend(transactionId, transition, role)) {
+      console.warn(`🔄 [DUPLICATE] SMS suppressed for ${transactionId}:${transition}:${role} within ${DUPLICATE_WINDOW_MS}ms window`);
+      return { suppressed: true, reason: 'duplicate_within_window' };
+    }
+  }
+
+  // Normalize the phone number to E.164
+  const toE164 = normalizePhoneNumber(to);
+  if (!toE164) {
     console.warn(`📱 Invalid phone number format: ${to}`);
     return Promise.resolve();
   }
 
   // E.164 validation
-  if (!isE164(formattedPhone)) {
+  if (!isE164(toE164)) {
     console.warn('[SMS] invalid phone, aborting:', to ? maskPhone(to) : 'null');
     throw new Error('Invalid E.164 phone');
   }
 
   // Check STOP list
-  if (stopList.has(formattedPhone)) {
-    console.warn('[SMS] suppressed: number opted out (STOP):', maskPhone(formattedPhone));
-    return { suppressed: true };
+  if (stopList.has(toE164)) {
+    console.warn('[SMS] suppressed: number opted out (STOP):', maskPhone(toE164));
+    return { suppressed: true, reason: 'stop_list' };
   }
 
   // 🔍 CRITICAL INVESTIGATION: Get call stack to identify which function called sendSMS
@@ -99,16 +107,24 @@ function sendSMS(to, message) {
   
   console.log(`📱 [CRITICAL] === SEND SMS CALLED ===`);
   console.log(`📱 [CRITICAL] Caller function: ${caller}`);
-  console.log(`📱 [CRITICAL] Recipient phone: ${maskPhone(formattedPhone)} (original: ${maskPhone(to)})`);
+  console.log(`📱 [CRITICAL] Raw phone: ${maskPhone(to)}`);
+  console.log(`📱 [CRITICAL] E.164 phone: ${maskPhone(toE164)}`);
   console.log(`📱 [CRITICAL] SMS message: ${message}`);
-  if (devFullLogs) console.debug('[DEV ONLY] full number:', formattedPhone);
+  console.log(`📱 [CRITICAL] Role: ${role || 'none'}`);
+  if (transactionId && transition) {
+    console.log(`📱 [CRITICAL] Transaction: ${transactionId}:${transition}`);
+  }
+  if (devFullLogs) {
+    console.debug('[DEV ONLY] Raw number:', to);
+    console.debug('[DEV ONLY] E.164 number:', toE164);
+  }
   console.log(`📱 [CRITICAL] ========================`);
 
   const payload = {
-    to: normalizedPhone, // real E.164
+    to: toE164, // real E.164 - unmasked
     body: message,
     statusCallback: process.env.PUBLIC_BASE_URL
-      ? `${process.env.PUBLIC_BASE_URL}/twilio/sms-status`
+      ? `${process.env.PUBLIC_BASE_URL}/api/twilio/sms-status`
       : undefined,
   };
 
@@ -121,18 +137,25 @@ function sendSMS(to, message) {
   return client.messages
     .create(payload)
     .then(msg => {
-      sent('unknown');
-      console.log(`📤 [CRITICAL] SMS sent successfully to ${maskPhone(formattedPhone)}`);
+      // Success
+      if (role) sent(role);
+      console.log(`📤 [CRITICAL] SMS sent successfully to ${maskPhone(toE164)}`);
       console.log(`📤 [CRITICAL] Twilio message SID: ${msg.sid}`);
+      console.log(`📤 [CRITICAL] Raw → E.164: ${maskPhone(to)} → ${maskPhone(toE164)}`);
       return msg;
     })
     .catch(err => {
       const code = err?.code || err?.status || 'unknown';
-      failed('unknown', code);
-      console.warn('[SMS] failed', { code, to: maskPhone(formattedPhone) });
+      if (role) failed(role, code);
+      console.warn('[SMS] failed', { 
+        code, 
+        rawPhone: maskPhone(to), 
+        e164Phone: maskPhone(toE164),
+        error: err.message 
+      });
 
       // 21610: STOP. Avoid future sends in this process.
-      if (String(code) === '21610') stopList.add(formattedPhone);
+      if (String(code) === '21610') stopList.add(toE164);
       throw err;
     });
 }

--- a/server/api-util/sendSMS.js
+++ b/server/api-util/sendSMS.js
@@ -123,9 +123,9 @@ function sendSMS(to, message) {
   const payload = {
     to: toE164, // real E.164 - unmasked
     body: message,
-    statusCallback: process.env.PUBLIC_BASE_URL
-      ? `${process.env.PUBLIC_BASE_URL}/api/twilio/sms-status`
-      : undefined,
+      statusCallback: process.env.PUBLIC_BASE_URL
+    ? `${process.env.PUBLIC_BASE_URL}/api/twilio/sms-status`
+    : undefined,
   };
 
   // Always use Messaging Service for better deliverability

--- a/server/api-util/sendSMS.js
+++ b/server/api-util/sendSMS.js
@@ -132,7 +132,9 @@ function sendSMS(to, message) {
   if (process.env.TWILIO_MESSAGING_SERVICE_SID) {
     payload.messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
   } else {
-    console.warn('⚠️ TWILIO_MESSAGING_SERVICE_SID not set - using fallback phone number');
+    console.error('❌ TWILIO_MESSAGING_SERVICE_SID not set - SMS may fail');
+    console.error('❌ Please set TWILIO_MESSAGING_SERVICE_SID in your environment');
+    // Still try with fallback, but warn that it may not work
     payload.from = process.env.TWILIO_PHONE_NUMBER;
   }
 

--- a/server/api/initiate-privileged.js
+++ b/server/api/initiate-privileged.js
@@ -22,9 +22,11 @@ console.log('🚦 initiate-privileged endpoint is wired up');
 
 // Helper function to build carrier-friendly lender SMS message
 function buildLenderMsg(tx, listingTitle) {
-  // Carrier-friendly: short, one link, no emojis
-  const lenderInboxUrl = process.env.ROOT_URL || 'https://sherbrt.com/inbox/sales';
-  const lenderMsg = `Sherbrt: new booking request for "${listingTitle}". Check your inbox: ${lenderInboxUrl}`;
+  const lenderInboxUrl = process.env.ROOT_URL ? `${process.env.ROOT_URL}/inbox/sales` : '/inbox/sales';
+  const lenderMsg =
+    `👗🍧 New Sherbrt booking request! ` +
+    `Someone wants to borrow your listing "${listingTitle}". ` +
+    `Check your inbox to respond: ${lenderInboxUrl}`;
   return lenderMsg;
 }
 
@@ -184,10 +186,11 @@ module.exports = (req, res) => {
             try {
               console.log('📨 [SMS][customer-confirmation] Preparing to send customer confirmation SMS');
               
-                              const listingTitle = listing?.attributes?.title || 'your listing';
-                // Carrier-friendly borrower message
-                const borrowerInboxUrl = process.env.ROOT_URL || 'https://sherbrt.com/inbox/orders';
-                const borrowerMsg = `Sherbrt: your booking request for "${listingTitle}" was sent. Track in your inbox: ${borrowerInboxUrl}`;
+              const listingTitle = listing?.attributes?.title || 'your listing';
+              const borrowerInboxUrl = process.env.ROOT_URL ? `${process.env.ROOT_URL}/inbox/orders` : '/inbox/orders';
+              const borrowerMsg =
+                `✅ Request sent! Your booking request for "${listingTitle}" was delivered. ` +
+                `Track and reply in your inbox: ${borrowerInboxUrl}`;
               
               await sendSMS(borrowerPhone, customerMessage);
               console.log(`✅ [SMS][customer-confirmation] Customer confirmation sent to ${borrowerPhone}`);

--- a/server/api/initiate-privileged.js
+++ b/server/api/initiate-privileged.js
@@ -20,9 +20,12 @@ try {
 
 console.log('🚦 initiate-privileged endpoint is wired up');
 
-// Helper function to build lender SMS message
+// Helper function to build carrier-friendly lender SMS message
 function buildLenderMsg(tx, listingTitle) {
-  return `👗 New Sherbrt booking request! Someone wants to borrow your item "${listingTitle}". Tap your dashboard to respond.`;
+  // Carrier-friendly: short, one link, no emojis
+  const lenderInboxUrl = process.env.ROOT_URL || 'https://sherbrt.com/inbox/sales';
+  const lenderMsg = `Sherbrt: new booking request for "${listingTitle}". Check your inbox: ${lenderInboxUrl}`;
+  return lenderMsg;
 }
 
 module.exports = (req, res) => {
@@ -181,8 +184,10 @@ module.exports = (req, res) => {
             try {
               console.log('📨 [SMS][customer-confirmation] Preparing to send customer confirmation SMS');
               
-              const listingTitle = listing?.attributes?.title || 'your listing';
-              const customerMessage = `✅ Your booking request for "${listingTitle}" has been sent! The lender will review and respond soon.`;
+                              const listingTitle = listing?.attributes?.title || 'your listing';
+                // Carrier-friendly borrower message
+                const borrowerInboxUrl = process.env.ROOT_URL || 'https://sherbrt.com/inbox/orders';
+                const borrowerMsg = `Sherbrt: your booking request for "${listingTitle}" was sent. Track in your inbox: ${borrowerInboxUrl}`;
               
               await sendSMS(borrowerPhone, customerMessage);
               console.log(`✅ [SMS][customer-confirmation] Customer confirmation sent to ${borrowerPhone}`);

--- a/server/api/qr.js
+++ b/server/api/qr.js
@@ -132,7 +132,13 @@ module.exports = ({ sharetribeSdk, shippo }) => {
         expiresIn: outboundQrCodeExpiry ? outboundQrCodeExpiry - nowSec : 'unknown'
       });
       
-      // 302 redirect to the (fresh) Shippo QR URL
+      // 302 redirect to the (fresh) Shippo QR URL with cache control and robots headers
+      res.set({
+        'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0',
+        'X-Robots-Tag': 'noindex, nofollow'
+      });
       res.redirect(302, outboundQrCodeUrl);
       
     } catch (err) {

--- a/server/api/qr.js
+++ b/server/api/qr.js
@@ -1,0 +1,168 @@
+const express = require('express');
+const router = express.Router();
+
+module.exports = ({ sharetribeSdk, shippo }) => {
+  /**
+   * Parse the Expires parameter from a Shippo URL
+   * @param {string} url - The Shippo URL with Expires query parameter
+   * @returns {number|null} - Expiry timestamp in seconds, or null if not found
+   */
+  function parseExpiresParam(url) {
+    try {
+      const u = new URL(url);
+      const exp = u.searchParams.get('Expires');
+      return exp ? Number(exp) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * GET /qr/:transactionId
+   * Redirects to a valid Shippo QR code, refreshing if expired
+   */
+  router.get('/qr/:transactionId', async (req, res) => {
+    const { transactionId } = req.params;
+    
+    try {
+      console.log(`🔍 [QR] Processing request for transaction: ${transactionId}`);
+      
+      // Get the transaction with protectedData (privileged)
+      const txRes = await sharetribeSdk.transactions.show({ 
+        id: transactionId, 
+        include: [] 
+      });
+      
+      const tx = txRes?.data?.data;
+      if (!tx) {
+        console.warn(`⚠️ [QR] Transaction not found: ${transactionId}`);
+        return res.status(404).send(`
+          <html>
+            <body>
+              <h2>QR Code Not Found</h2>
+              <p>The requested QR code for transaction ${transactionId} could not be found.</p>
+              <p>Please contact support if you believe this is an error.</p>
+            </body>
+          </html>
+        `);
+      }
+      
+      const pd = tx?.attributes?.protectedData || {};
+      let { outboundQrCodeUrl, outboundQrCodeExpiry, outboundShippoTxId } = pd;
+      
+      console.log(`📱 [QR] Transaction found, checking QR code availability:`, {
+        hasQrUrl: !!outboundQrCodeUrl,
+        hasExpiry: !!outboundQrCodeExpiry,
+        hasShippoTxId: !!outboundShippoTxId,
+        currentTime: Math.floor(Date.now() / 1000),
+        expiryTime: outboundQrCodeExpiry
+      });
+      
+      const nowSec = Math.floor(Date.now() / 1000);
+      const freshNeeded = !outboundQrCodeUrl || 
+                         !outboundQrCodeExpiry || 
+                         outboundQrCodeExpiry < (nowSec + 120); // 2-minute buffer
+      
+      if (freshNeeded && outboundShippoTxId) {
+        console.log(`🔄 [QR] QR code expired or missing, refreshing from Shippo...`);
+        
+        try {
+          // Re-retrieve Shippo transaction to get fresh signed URLs
+          const shippoTx = await shippo.transaction.retrieve(outboundShippoTxId);
+          
+          if (shippoTx?.qr_code_url) {
+            outboundQrCodeUrl = shippoTx.qr_code_url;
+            outboundQrCodeExpiry = parseExpiresParam(outboundQrCodeUrl);
+            
+            console.log(`✅ [QR] Successfully refreshed QR code:`, {
+              newUrl: maskUrl(outboundQrCodeUrl),
+              newExpiry: outboundQrCodeExpiry,
+              expiresIn: outboundQrCodeExpiry ? outboundQrCodeExpiry - nowSec : 'unknown'
+            });
+            
+            // Save refreshed values back to Flex via privileged transition
+            try {
+              await sharetribeSdk.transactions.transition({
+                id: transactionId,
+                transition: 'transition/store-shipping-urls',
+                params: {
+                  protectedData: {
+                    outboundQrCodeUrl,
+                    outboundQrCodeExpiry
+                  }
+                }
+              });
+              console.log(`💾 [QR] Refreshed QR code saved to transaction`);
+            } catch (transitionError) {
+              console.warn(`⚠️ [QR] Failed to save refreshed QR code:`, transitionError.message);
+              // Continue with the redirect even if save fails
+            }
+          } else {
+            console.warn(`⚠️ [QR] Shippo transaction retrieval failed or no QR code URL`);
+          }
+        } catch (shippoError) {
+          console.error(`❌ [QR] Error refreshing from Shippo:`, shippoError.message);
+          // Continue with existing URL if available
+        }
+      }
+      
+      if (!outboundQrCodeUrl) {
+        console.warn(`⚠️ [QR] No QR code URL available for transaction: ${transactionId}`);
+        return res.status(404).send(`
+          <html>
+            <body>
+              <h2>QR Code Not Available</h2>
+              <p>The QR code for transaction ${transactionId} is not currently available.</p>
+              <p>This may be due to:</p>
+              <ul>
+                <li>The shipping label has expired</li>
+                <li>The transaction is still being processed</li>
+                <li>A system error occurred</li>
+              </ul>
+              <p>Please contact support for assistance.</p>
+            </body>
+          </html>
+        `);
+      }
+      
+      // Log the redirect (masked for security)
+      console.log(`🔄 [QR] Redirecting to QR code:`, {
+        transactionId,
+        redirectUrl: maskUrl(outboundQrCodeUrl),
+        expiresIn: outboundQrCodeExpiry ? outboundQrCodeExpiry - nowSec : 'unknown'
+      });
+      
+      // 302 redirect to the (fresh) Shippo QR URL
+      res.redirect(302, outboundQrCodeUrl);
+      
+    } catch (err) {
+      console.error(`❌ [QR] Error processing QR request for ${transactionId}:`, err.message);
+      res.status(500).send(`
+        <html>
+          <body>
+            <h2>Service Temporarily Unavailable</h2>
+            <p>We're experiencing technical difficulties loading the QR code.</p>
+            <p>Please try again in a few minutes or contact support if the problem persists.</p>
+          </body>
+        </html>
+      `);
+    }
+  });
+
+  /**
+   * Mask sensitive parts of URLs in logs
+   * @param {string} url - The URL to mask
+   * @returns {string} - Masked URL for logging
+   */
+  function maskUrl(url) {
+    if (!url) return 'null';
+    try {
+      const u = new URL(url);
+      return `${u.protocol}//${u.host}${u.pathname}...`;
+    } catch {
+      return '[invalid-url]';
+    }
+  }
+
+  return router;
+};

--- a/server/api/qr.js
+++ b/server/api/qr.js
@@ -18,10 +18,10 @@ module.exports = ({ sharetribeSdk, shippo }) => {
   }
 
   /**
-   * GET /qr/:transactionId
+   * GET /api/qr/:transactionId
    * Redirects to a valid Shippo QR code, refreshing if expired
    */
-  router.get('/qr/:transactionId', async (req, res) => {
+  router.get('/api/qr/:transactionId', async (req, res) => {
     const { transactionId } = req.params;
     
     try {

--- a/server/api/qr.js
+++ b/server/api/qr.js
@@ -22,7 +22,7 @@ module.exports = ({ getTrustedSdk }) => {
     sdk = sdk || req.app.get('integrationSdk') || req.app.get('apiSdk');
 
     return res.status(sdk ? 200 : 500).json({
-      hasSdk: !!sdk,
+      ok: !!sdk,
       hasTransactionsShow: !!sdk?.transactions?.show,
       from: {
         getTrustedSdk: typeof getTrustedSdk === 'function',

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -27,12 +27,15 @@ const maskUrl = (u) => {
 
 // Helper function to parse expiry from QR code URL
 function parseExpiresParam(url) {
-  try { 
-    const u = new URL(url); 
-    const exp = u.searchParams.get('Expires'); 
-    return exp ? new Date(Number(exp) * 1000).toISOString() : null; 
-  } catch { 
-    return null; 
+  try {
+    const u = new URL(url);
+    const raw = u.searchParams.get('Expires');
+    if (!raw) return null;
+    const seconds = Number(raw);
+    if (!Number.isFinite(seconds)) return null;
+    return new Date(seconds * 1000).toISOString(); // normalize to ISO
+  } catch {
+    return null;
   }
 }
 
@@ -266,7 +269,7 @@ async function createShippingLabels({
         outboundQrExpiry: parseExpiresParam(qrUrl),
         outboundPurchasedAt: new Date().toISOString(),
       };
-      await integrationSdk.transactions.updateProtectedData({ id: txId, protectedData: patch });
+      await integrationSdk.transactions.update({ id: txId, protectedData: patch });
       console.log('📝 [SHIPPO] Stored outbound shipping artifacts in protectedData', { txId, fields: Object.keys(patch) });
     } catch (e) {
       console.error('[SHIPPO] Failed to persist outbound label details to protectedData', e);
@@ -307,7 +310,7 @@ async function createShippingLabels({
 
     // Parse expiry from QR code URL (keep existing logic)
     const qrExpiry = parseExpiresParam(qrUrl);
-    console.log('📦 [SHIPPO] QR code expiry:', qrExpiry ? new Date(Number(qrExpiry) * 1000).toISOString() : 'unknown');
+    console.log('📦 [SHIPPO] QR code expiry:', qrExpiry || 'unknown');
 
     // after outbound purchase success:
     console.log('[SHIPPO][TX]', logTx(shippoTx));
@@ -427,7 +430,7 @@ async function createShippingLabels({
                 returnQrExpiry: parseExpiresParam(returnQrUrl || ''),
                 returnPurchasedAt: new Date().toISOString(),
               };
-              await integrationSdk.transactions.updateProtectedData({ id: txId, protectedData: patch });
+              await integrationSdk.transactions.update({ id: txId, protectedData: patch });
               console.log('📝 [SHIPPO] Stored return shipping artifacts in protectedData', { txId, fields: Object.keys(patch) });
             } catch (e) {
               console.error('[SHIPPO] Failed to persist return label details to protectedData', e);

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -49,6 +49,8 @@ const logTx = (tx) => ({
 });
 // ---------------------------------------
 
+const { getIntegrationSdk, txUpdateProtectedData } = require('../api-util/integrationSdk');
+
 // Conditional import of sendSMS to prevent module loading errors
 let sendSMS = null;
 try {
@@ -269,12 +271,8 @@ async function createShippingLabels({
         outboundQrExpiry: parseExpiresParam(qrUrl),
         outboundPurchasedAt: new Date().toISOString(),
       };
-      const result = await txUpdateProtectedData({ id: txId, protectedData: patch });
-      if (result && result.success === false) {
-        console.warn('📝 [SHIPPO] Persistence not available, but SMS will continue:', result.reason);
-      } else {
-        console.log('📝 [SHIPPO] Stored outbound shipping artifacts in protectedData', { txId, fields: Object.keys(patch) });
-      }
+      await txUpdateProtectedData({ id: txId, protectedData: patch });
+      console.log('📝 [SHIPPO] Stored outbound shipping artifacts in protectedData', { txId, fields: Object.keys(patch) });
     } catch (e) {
       console.error('[SHIPPO] Failed to persist outbound label details to protectedData', e);
     }
@@ -428,12 +426,8 @@ async function createShippingLabels({
                 returnQrExpiry: parseExpiresParam(returnQrUrl || ''),
                 returnPurchasedAt: new Date().toISOString(),
               };
-              const result = await txUpdateProtectedData({ id: txId, protectedData: patch });
-              if (result && result.success === false) {
-                console.warn('📝 [SHIPPO] Return persistence not available, but SMS will continue:', result.reason);
-              } else {
-                console.log('📝 [SHIPPO] Stored return shipping artifacts in protectedData', { txId, fields: Object.keys(patch) });
-              }
+              await txUpdateProtectedData({ id: txId, protectedData: patch });
+              console.log('📝 [SHIPPO] Stored return shipping artifacts in protectedData', { txId, fields: Object.keys(patch) });
             } catch (e) {
               console.error('[SHIPPO] Failed to persist return label details to protectedData', e);
             }

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -261,7 +261,15 @@ async function createShippingLabels(protectedData, transactionId, listing, sendS
 
     // Build short URL from live host (no hardcoding)
     const txIdStr = String(transactionId);
-    const base = process.env.ROOT_URL || `${req.protocol}://${req.get('host')}`;
+    const base =
+      process.env.ROOT_URL ||
+      (req ? `${req.protocol}://${req.get('host')}` : null);
+
+    if (!base) {
+      console.warn('[LENDER_SMS] No ROOT_URL and no req — skipping link build');
+      return { success: false, reason: 'no_base_url_available' };
+    }
+
     const shortUrl = `${base}/api/qr/${txIdStr}`;
 
     // Resolve lender phone
@@ -943,7 +951,7 @@ module.exports = async (req, res) => {
           const providerName = params?.protectedData?.providerName || 'the lender';
           
           // Build dynamic site base for borrower inbox link
-          const siteBase = process.env.ROOT_URL || (req ? `${req.protocol}://${req.get('host')}` : null);
+          const siteBase = process.env.ROOT_URL || (req ? `${req.protocol}://${req.get('host')}` : 'https://sherbrt.com');
           const buyerLink = `${siteBase}/inbox/purchases`;
           
           const message = `🎉 Your Sherbrt request was accepted! 🍧

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -942,9 +942,13 @@ module.exports = async (req, res) => {
           const listingTitle = listing?.attributes?.title || 'your item';
           const providerName = params?.protectedData?.providerName || 'the lender';
           
-          const message = `👗 Your Sherbrt request was accepted! 
-"${listingTitle}" is confirmed by ${providerName}. 
-Check your inbox for next steps: https://sherbrt.com/inbox/purchases`;
+          // Build dynamic site base for borrower inbox link
+          const siteBase = process.env.ROOT_URL || (req ? `${req.protocol}://${req.get('host')}` : null);
+          const buyerLink = `${siteBase}/inbox/purchases`;
+          
+          const message = `🎉 Your Sherbrt request was accepted! 🍧
+"${listingTitle}" from ${providerName} is confirmed. 
+You'll receive tracking info once it ships! ✈️👗 ${buyerLink}`;
           
           // Wrap sendSMS in try/catch with logs
           try {

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -9,15 +9,37 @@ const {
 } = require('../api-util/sdk');
 const { maskPhone } = require('../api-util/phone');
 
+// Helper function to safely pick specific keys from an object
+const pick = (obj, keys = []) => {
+  if (!obj || typeof obj !== 'object') return {};
+  return keys.reduce((acc, k) => {
+    if (k in obj) acc[k] = obj[k];
+    return acc;
+  }, {});
+};
+
 // Helper function to mask sensitive parts of URLs in logs
 function maskUrl(url) {
   if (!url) return 'null';
   try {
     const u = new URL(url);
-    return `${u.protocol}//${u.host}${u.pathname}...`;
-  } catch {
-    return '[invalid-url]';
+    u.search = ''; // strip query
+    return u.toString();
+  } catch { 
+    return String(url).split('?')[0]; 
   }
+}
+
+// Helper function to log transaction data safely for debugging
+function logTx(tx) {
+  return {
+    object_id: tx?.object_id,
+    status: tx?.status,
+    tracking_number: tx?.tracking_number,
+    tracking_url_provider: maskUrl(tx?.tracking_url_provider),
+    label_url: maskUrl(tx?.label_url),
+    qr_code_url: maskUrl(tx?.qr_code_url),
+  };
 }
 
 // Conditional import of sendSMS to prevent module loading errors
@@ -194,8 +216,16 @@ async function createShippingLabels({
 
     // One-time debug log after label purchase - safe structured logging of key fields
     if (process.env.SHIPPO_DEBUG === 'true') {
-      console.log('[SHIPPO][TX]', logTx(shippoTx));
-      console.log('[SHIPPO][RATE]', safePick(selectedRate || {}, ['provider', 'servicelevel', 'service', 'object_id']));
+      const logTx = tx => ({
+        object_id: tx?.object_id,
+        status: tx?.status,
+        tracking_number: tx?.tracking_number,
+        tracking_url_provider: maskUrl(tx?.tracking_url_provider),
+        label_url: maskUrl(tx?.label_url),
+        qr_code_url: maskUrl(tx?.qr_code_url),
+      });
+      console.log('[SHIPPO][TX]', logTx(transactionRes.data));
+      console.log('[SHIPPO][RATE]', pick(selectedRate || {}, ['provider', 'servicelevel', 'object_id']));
     }
     const tx = shippoTx || {};
     const trackingNumber = tx.tracking_number || null;
@@ -236,6 +266,29 @@ async function createShippingLabels({
     
     const qrExpiry = parseExpiresParam(qrCodeUrl);
     console.log('📦 [SHIPPO] QR code expiry:', qrExpiry ? new Date(qrExpiry * 1000).toISOString() : 'unknown');
+
+    // IMPORTANT: Send lender SMS immediately after outbound label success
+    // This ensures the SMS is sent even if subsequent steps fail
+    try {
+      const lenderPhone = protectedData.providerPhone;
+      if (lenderPhone && qrCodeUrl) {
+        const shortUrl = `${process.env.ROOT_URL || 'https://sherbrt.com'}/api/qr/${transactionId}`;
+        await sendSMS({
+          to: lenderPhone,
+          role: 'lender',
+          message: `📬 Your Sherbrt shipping label is ready! 🍧 Use this QR to ship: ${shortUrl}`
+        });
+        console.log(`📱 [CRITICAL] Lender SMS sent immediately after outbound label success to ${maskPhone(lenderPhone)}`);
+        console.log(`📱 [CRITICAL] Short URL: ${shortUrl}`);
+      } else if (lenderPhone) {
+        console.warn('⚠️ [CRITICAL] Lender phone found but no QR code URL available for immediate SMS');
+      } else {
+        console.warn('⚠️ [CRITICAL] Lender phone number not found for immediate SMS');
+      }
+    } catch (smsError) {
+      console.error('❌ [CRITICAL] Failed to send immediate lender SMS:', smsError.message);
+      // Don't fail the label creation if SMS fails
+    }
 
     // Create return shipment (customer → provider) if we have return address
     let returnLabelRes = null;
@@ -300,6 +353,12 @@ async function createShippingLabels({
         );
         
         if (returnTransactionRes.data.status === 'SUCCESS') {
+          // One-time debug log for return label purchase
+          if (process.env.SHIPPO_DEBUG === 'true') {
+            console.log('[SHIPPO][RETURN_TX]', logTx(returnTransactionRes.data));
+            console.log('[SHIPPO][RETURN_RATE]', pick(returnSelectedRate || {}, ['provider', 'servicelevel', 'object_id']));
+          }
+          
           returnQrCodeUrl = returnTransactionRes.data.qr_code_url;
           returnTrackingUrl = returnTransactionRes.data.tracking_url_provider || returnTransactionRes.data.tracking_url;
           
@@ -405,31 +464,17 @@ async function createShippingLabels({
         });
       }
     
-    // Send SMS notifications for shipping labels
+    // Send borrower SMS notification (lender SMS already sent immediately after outbound label success)
     try {
       // Extract phone numbers from protectedData (more reliable than nested objects)
-      const lenderPhone = protectedData.providerPhone;
       const borrowerPhone = protectedData.customerPhone;
       
-              // Trigger 4: Lender receives text when QR code/shipping label is sent to them
-        if (lenderPhone) {
-          if (qrCodeUrl) {
-            // Use branded short URL instead of raw Shippo URL
-            const qrBaseUrl = process.env.PUBLIC_QR_BASE_URL || 'https://sherbrt.com/api/qr';
-            const shortUrl = `${qrBaseUrl}/${transactionId}`;
-            const message = `📬 Your Sherbrt shipping label is ready! 🍧 Use this QR to ship: ${shortUrl}`;
-          
-          await sendSMS(
-            lenderPhone,
-            message,
-            { 
-              role: 'lender',
-              transactionId: transactionId,
-              transition: 'transition/accept'
-            }
-          );
-          console.log(`📱 SMS sent to lender (${maskPhone(lenderPhone)}) for shipping label ready with short URL: ${shortUrl}`);
-          console.log(`📱 [DEBUG] Raw Shippo QR URL: ${maskUrl(qrCodeUrl)}`);
+      // Optional: Send borrower "Label created" message (idempotent)
+      if (borrowerPhone && trackingUrl) {
+        // Check if we've already sent this notification
+        const existingNotification = protectedData.shippingNotification?.labelCreated;
+        if (existingNotification?.sent === true) {
+          console.log(`📱 Label created SMS already sent to borrower (${maskPhone(borrowerPhone)}) - skipping`);
         } else {
           await sendSMS(
             borrowerPhone,
@@ -479,7 +524,7 @@ async function createShippingLabels({
       }
       
     } catch (smsError) {
-      console.error('❌ Failed to send shipping SMS notifications:', smsError.message);
+      console.error('❌ Failed to send borrower SMS notification:', smsError.message);
       // Don't fail the label creation if SMS fails
     }
     
@@ -497,10 +542,19 @@ async function createShippingLabels({
     };
     
   } catch (err) {
-    console.error('❌ [SHIPPO] Label creation failed:', err.message);
-    if (err.response?.data) {
-      console.error('❌ [SHIPPO] Shippo API error details:', err.response.data);
-    }
+    const details = {
+      name: err?.name,
+      message: err?.message,
+      status: err?.status || err?.response?.status,
+      statusText: err?.statusText || err?.response?.statusText,
+      data: err?.response?.data ? pick(err.response.data, ['error', 'message', 'code']) : undefined,
+      labelUrl: err?.label_url ? maskUrl(err.label_url) : undefined,
+      qrUrl: err?.qr_code_url ? maskUrl(err.qr_code_url) : undefined,
+    };
+    console.error('[SHIPPO] Label creation failed', details);
+
+    // IMPORTANT: don't throw here if outbound label succeeded.
+    // Continue to send the lender SMS with the outbound QR even if saving/return label fails.
     return { success: false, reason: 'api_error', error: err.message };
   }
 }
@@ -1116,7 +1170,7 @@ You'll receive tracking info once it ships! ✈️👗 ${buyerLink}`;
           }
 
           if (sendSMS) {
-            const message = `👗 New Sherbrt booking request! Someone wants to borrow your item "${listing?.attributes?.title || 'your listing'}". Tap your dashboard to respond.`;
+            const message = `👗🍧 New Sherbrt booking request! Someone wants to borrow your item "${listing?.attributes?.title || 'your listing'}". Tap your dashboard to respond.`;
             
             await sendSMS(providerPhone, message);
             console.log(`✅ [SMS][booking-request] SMS sent to provider ${providerPhone}`);

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -407,7 +407,7 @@ async function createShippingLabels({
       if (lenderPhone) {
         if (qrCodeUrl) {
           // Use branded short URL instead of raw Shippo URL
-          const shortUrl = `https://sherbrt.com/qr/${transactionId}`;
+          const shortUrl = `https://sherbrt.com/api/qr/${transactionId}`;
           const message = `📬 Your Sherbrt shipping label is ready! 🍧 Use this QR to ship: ${shortUrl}`;
           
           await sendSMS(

--- a/server/api/twilio/sms-status.js
+++ b/server/api/twilio/sms-status.js
@@ -1,0 +1,16 @@
+// server/api/twilio/sms-status.js
+const express = require('express');
+const { maskPhone } = require('../../api-util/phone');
+
+module.exports = async (req, res) => {
+  const { MessageSid, MessageStatus, ErrorCode, To } = req.body || {};
+  
+  console.log('[SMS][DLR]', { 
+    sid: MessageSid, 
+    status: MessageStatus, 
+    error: ErrorCode, 
+    to: maskPhone(To) 
+  });
+  
+  res.sendStatus(204);
+};

--- a/server/api/twilio/sms-status.js
+++ b/server/api/twilio/sms-status.js
@@ -9,7 +9,7 @@ module.exports = async (req, res) => {
     sid: MessageSid, 
     status: MessageStatus, 
     error: ErrorCode, 
-    to: maskPhone(To) 
+    to: To // Show actual phone number for debugging
   });
   
   res.sendStatus(204);

--- a/server/api/twilio/sms-status.js
+++ b/server/api/twilio/sms-status.js
@@ -5,12 +5,25 @@ const { maskPhone } = require('../../api-util/phone');
 module.exports = async (req, res) => {
   const { MessageSid, MessageStatus, ErrorCode, To } = req.body || {};
   
-  console.log('[SMS][DLR]', { 
-    sid: MessageSid, 
-    status: MessageStatus, 
-    error: ErrorCode, 
-    to: To // Show actual phone number for debugging
-  });
+  // Enhanced delivery receipt logging
+  const status = MessageStatus || 'unknown';
+  const error = ErrorCode || '';
+  const phone = To || 'unknown';
+  
+  console.log(`[DLR] ${phone} ${MessageSid} -> ${status} ${error}`);
+  
+  // Log specific error conditions
+  if (status === 'delivered') {
+    console.log(`✅ [DLR] Message delivered successfully to ${phone}`);
+  } else if (status === 'undelivered' || status === 'failed') {
+    if (error === '30007') {
+      console.log(`🚫 [DLR] Carrier filtered message to ${phone} (content issue)`);
+    } else if (error === '21610') {
+      console.log(`🚫 [DLR] Recipient opted out: ${phone} must text START to resume`);
+    } else {
+      console.log(`❌ [DLR] Message failed to ${phone}: ${status} (${error})`);
+    }
+  }
   
   res.sendStatus(204);
 };

--- a/server/apiRouter.js
+++ b/server/apiRouter.js
@@ -63,7 +63,8 @@ router.post('/transition-privileged', transitionPrivileged);
 router.use('/webhooks', shippoWebhook);
 
 // QR code redirect endpoint
-router.use('/qr', qrRouter({ getTrustedSdk }));
+const qrRouterInstance = qrRouter({ getTrustedSdk }); // factory export
+router.use('/qr', qrRouterInstance);
 
 // Create user with identity provider (e.g. Facebook or Google)
 // This endpoint is called to create a new user after user has confirmed

--- a/server/apiRouter.js
+++ b/server/apiRouter.js
@@ -63,7 +63,7 @@ router.post('/transition-privileged', transitionPrivileged);
 router.use('/webhooks', shippoWebhook);
 
 // QR code redirect endpoint
-router.use('/', qrRouter({ 
+router.use('/qr', qrRouter({ 
   sharetribeSdk: require('./api-util/sdk').getTrustedSdk,
   shippo: require('axios').create({
     baseURL: 'https://api.goshippo.com',

--- a/server/apiRouter.js
+++ b/server/apiRouter.js
@@ -8,7 +8,7 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
-const { deserialize } = require('./api-util/sdk');
+const { deserialize, getTrustedSdk } = require('./api-util/sdk');
 
 const initiateLoginAs = require('./api/initiate-login-as');
 const loginAs = require('./api/login-as');
@@ -63,16 +63,7 @@ router.post('/transition-privileged', transitionPrivileged);
 router.use('/webhooks', shippoWebhook);
 
 // QR code redirect endpoint
-router.use('/qr', qrRouter({ 
-  sharetribeSdk: require('./api-util/sdk').getTrustedSdk,
-  shippo: require('axios').create({
-    baseURL: 'https://api.goshippo.com',
-    headers: {
-      'Authorization': `ShippoToken ${process.env.SHIPPO_API_TOKEN}`,
-      'Content-Type': 'application/json'
-    }
-  })
-}));
+router.use('/qr', qrRouter({ getTrustedSdk }));
 
 // Create user with identity provider (e.g. Facebook or Google)
 // This endpoint is called to create a new user after user has confirmed

--- a/server/apiRouter.js
+++ b/server/apiRouter.js
@@ -16,6 +16,8 @@ const transactionLineItems = require('./api/transaction-line-items');
 const initiatePrivileged = require('./api/initiate-privileged');
 const transitionPrivileged = require('./api/transition-privileged');
 const shippoWebhook = require('./webhooks/shippoTracking');
+const qrRouter = require('./api/qr');
+const smsStatus = require('./api/twilio/sms-status');
 
 const createUserWithIdp = require('./api/auth/createUserWithIdp');
 const loginWithIdp = require('./api/auth/loginWithIdp');
@@ -60,6 +62,13 @@ router.post('/transition-privileged', transitionPrivileged);
 
 // Shippo webhook endpoint
 router.use('/webhooks', shippoWebhook);
+
+// Twilio SMS delivery receipt endpoint (no auth required - Twilio webhook)
+router.post('/twilio/sms-status', express.urlencoded({ extended: false }), smsStatus);
+
+// QR code redirect endpoint
+const qrRouterInstance = qrRouter({ getTrustedSdk }); // factory export
+router.use('/qr', qrRouterInstance);
 
 // Create user with identity provider (e.g. Facebook or Google)
 // This endpoint is called to create a new user after user has confirmed

--- a/server/csp.js
+++ b/server/csp.js
@@ -121,9 +121,8 @@ const defaultDirectives = {
     'js.stripe.com',
     'plausible.io',
   ],
-  "script-src-elem": [self, blob, "https://api.mapbox.com", "https://*.mapbox.com"],
-  "manifest-src": [self],
-  "worker-src": [self, blob],
+  "script-src-elem": ["'self'", "blob:", "https://api.mapbox.com", "https://*.mapbox.com"],
+  "manifest-src": ["'self'"],
   styleSrc: [self, unsafeInline, 'fonts.googleapis.com', 'api.mapbox.com'],
 };
 

--- a/server/csp.js
+++ b/server/csp.js
@@ -48,8 +48,6 @@ const defaultDirectives = {
     'events.mapbox.com',
 
     // Google Analytics
-    // TODO: Signals support needs more work
-    // https://developers.google.com/tag-platform/security/guides/csp
     '*.google-analytics.com',
     '*.analytics.google.com',
     '*.googletagmanager.com',
@@ -81,7 +79,7 @@ const defaultDirectives = {
     blob,
     ...devImagesMaybe,
     '*.imgix.net',
-    'sharetribe.imgix.net', // Safari 9.1 didn't recognize asterisk rule.
+    'sharetribe.imgix.net',
 
     // Styleguide placeholder images
     'picsum.photos',
@@ -121,9 +119,11 @@ const defaultDirectives = {
     'www.googleadservices.com',
     '*.g.doubleclick.net',
     'js.stripe.com',
-    // Plausible analytics
     'plausible.io',
   ],
+  "script-src-elem": [self, blob, "https://api.mapbox.com", "https://*.mapbox.com"],
+  "manifest-src": [self],
+  "worker-src": [self, blob],
   styleSrc: [self, unsafeInline, 'fonts.googleapis.com', 'api.mapbox.com'],
 };
 
@@ -147,9 +147,8 @@ exports.csp = (reportUri, reportOnly) => {
   // const { imgSrc = [self] } = defaultDirectives;
   // const exampleImgSrc = imgSrc.concat('my-custom-domain.example.com');
 
-  // Parse extra hosts from environment variable
+  // Parse extra hosts from environment variable (only for legitimate third-party services)
   const EXTRA_HOSTS = (process.env.CSP_EXTRA_HOSTS || '').split(/\s+/).filter(Boolean);
-  // e.g., set CSP_EXTRA_HOSTS="https://sherbrt-test.onrender.com https://sherbrt.com"
 
   const customDirectives = {
     // Example: Add custom directive override

--- a/server/index.js
+++ b/server/index.js
@@ -79,7 +79,6 @@ app.use((req, res, next) => {
 // Add CORS middleware configuration
 const allowedOrigins = [
   'https://sherbrt.com',        // live frontend
-  'https://web-template-1.onrender.com', // test environment
   'http://localhost:3000',      // local dev
 ];
 

--- a/server/test-flex-transition.js
+++ b/server/test-flex-transition.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify Flex transition exists and can be called
+ */
+
+const { getTrustedSdk } = require('./api-util/sdk');
+
+async function testFlexTransition() {
+  console.log('🧪 Testing Flex transition: transition/store-shipping-urls');
+  
+  try {
+    const sdk = await getTrustedSdk();
+    
+    // Test transaction ID (you'll need to replace this with a real one)
+    const testTransactionId = process.argv[2] || '68a3c0a3-0e4a-4cfd-b130-35d9345bcdde';
+    
+    console.log(`📋 Testing with transaction: ${testTransactionId}`);
+    
+    // First, try to show the transaction to see its current state
+    console.log('🔍 Fetching transaction details...');
+    const txResponse = await sdk.transactions.show({ 
+      id: testTransactionId,
+      include: []
+    });
+    
+    const tx = txResponse?.data?.data;
+    if (!tx) {
+      console.error('❌ Transaction not found');
+      return;
+    }
+    
+    console.log('✅ Transaction found:', {
+      id: tx.id,
+      state: tx.attributes.state,
+      protectedDataKeys: Object.keys(tx.attributes.protectedData || {})
+    });
+    
+    // Check if the transition is available
+    console.log('🔍 Checking available transitions...');
+    const transitionsResponse = await sdk.transactions.query({
+      id: testTransactionId,
+      include: ['transitions']
+    });
+    
+    const transitions = transitionsResponse?.data?.data?.[0]?.attributes?.transitions || [];
+    console.log('📋 Available transitions:', transitions.map(t => t.name));
+    
+    const hasStoreShippingUrls = transitions.some(t => t.name === 'transition/store-shipping-urls');
+    console.log(`🎯 transition/store-shipping-urls available: ${hasStoreShippingUrls ? 'YES' : 'NO'}`);
+    
+    if (!hasStoreShippingUrls) {
+      console.error('❌ transition/store-shipping-urls is not available');
+      console.log('💡 This means the Flex process needs to be redeployed');
+      return;
+    }
+    
+    // Try to call the transition with minimal data
+    console.log('🚀 Attempting to call transition/store-shipping-urls...');
+    
+    const testData = {
+      testTimestamp: new Date().toISOString(),
+      testValue: 'test'
+    };
+    
+    const transitionResponse = await sdk.transactions.transition({
+      id: testTransactionId,
+      transition: 'transition/store-shipping-urls',
+      params: {
+        protectedData: testData
+      }
+    });
+    
+    console.log('✅ Transition successful!');
+    console.log('📋 Response:', transitionResponse.data);
+    
+    // Verify the data was saved
+    console.log('🔍 Verifying data was saved...');
+    const verifyResponse = await sdk.transactions.show({ 
+      id: testTransactionId,
+      include: []
+    });
+    
+    const updatedTx = verifyResponse?.data?.data;
+    const savedData = updatedTx?.attributes?.protectedData || {};
+    
+    console.log('💾 Saved data:', {
+      testTimestamp: savedData.testTimestamp,
+      testValue: savedData.testValue,
+      allKeys: Object.keys(savedData)
+    });
+    
+  } catch (error) {
+    console.error('❌ Test failed:', error.message);
+    
+    if (error.response) {
+      console.error('📋 Response details:', {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        data: error.response.data
+      });
+    }
+    
+    console.error('🔍 Full error:', error);
+  }
+}
+
+// Run the test
+if (require.main === module) {
+  testFlexTransition().catch(console.error);
+}
+
+module.exports = { testFlexTransition };

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,7 +42,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.6.tgz"
   integrity sha512-tzulrgDT0QD6U7BJ4TKVk2SDDg7wlP39P9yAx1RfLy7vP/7rsDRlWVfbWxElslu56+r7QOhB2NSDsabYYruoZQ==
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.12.0", "@babel/core@^7.12.3", "@babel/core@^7.13.0", "@babel/core@^7.16.0", "@babel/core@^7.4.0-0", "@babel/core@^7.7.2", "@babel/core@^7.8.0", "@babel/core@>=7.11.0":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.18.6.tgz"
   integrity sha512-cQbWBpxcbbs/IUredIPkHiAGULLV8iwgNRMFzvbhEXISp4f3rUUXE5+TIw6KwUWUR3DwyI6gmBRnmAtYaWehwQ==
@@ -502,7 +502,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-flow@^7.18.6":
+"@babel/plugin-syntax-flow@^7.14.5", "@babel/plugin-syntax-flow@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz"
   integrity sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==
@@ -822,7 +822,7 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.18.6"
 
-"@babel/plugin-transform-react-jsx@^7.18.6":
+"@babel/plugin-transform-react-jsx@^7.14.9", "@babel/plugin-transform-react-jsx@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.18.6.tgz"
   integrity sha512-Mz7xMPxoy9kPS/JScj6fJs03TZ/fZ1dJPlMjRAgTaxaS0fUBk8FV/A2rRgfPsVCZqALNwMexD+0Uaf5zlcKPpw==
@@ -856,16 +856,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-runtime@7.12.1":
-  version "7.12.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz"
-  integrity sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.12.1"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    resolve "^1.8.1"
-    semver "^5.5.1"
-
 "@babel/plugin-transform-runtime@^7.16.4":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.18.6.tgz"
@@ -877,6 +867,16 @@
     babel-plugin-polyfill-corejs3 "^0.5.2"
     babel-plugin-polyfill-regenerator "^0.3.1"
     semver "^6.3.0"
+
+"@babel/plugin-transform-runtime@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz"
+  integrity sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    resolve "^1.8.1"
+    semver "^5.5.1"
 
 "@babel/plugin-transform-shorthand-properties@^7.18.6":
   version "7.18.6"
@@ -1335,6 +1335,11 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
+"@ioredis/commands@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz"
+  integrity sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
@@ -1659,7 +1664,7 @@
   dependencies:
     "@babel/plugin-syntax-dynamic-import" "^7.7.4"
 
-"@loadable/component@^5.16.4":
+"@loadable/component@^5.0.1", "@loadable/component@^5.16.4":
   version "5.16.4"
   resolved "https://registry.npmjs.org/@loadable/component/-/component-5.16.4.tgz"
   integrity sha512-fJWxx9b5WHX90QKmizo9B+es2so8DnBthI1mbflwCoOyvzEwxiZ/SVDCTtXEnHG72/kGBdzr297SSIekYtzSOQ==
@@ -1704,7 +1709,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1738,7 +1743,7 @@
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0":
+"@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.1.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.7.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0", "@opentelemetry/api@>=1.0.0 <1.10.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
@@ -1748,7 +1753,7 @@
   resolved "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz"
   integrity sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==
 
-"@opentelemetry/core@1.30.1", "@opentelemetry/core@^1.1.0", "@opentelemetry/core@^1.26.0", "@opentelemetry/core@^1.30.1", "@opentelemetry/core@^1.8.0":
+"@opentelemetry/core@^1.1.0", "@opentelemetry/core@^1.26.0", "@opentelemetry/core@^1.30.1", "@opentelemetry/core@^1.8.0", "@opentelemetry/core@1.30.1":
   version "1.30.1"
   resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz"
   integrity sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==
@@ -1899,15 +1904,6 @@
     "@opentelemetry/instrumentation" "^0.57.0"
     "@opentelemetry/semantic-conventions" "^1.27.0"
 
-"@opentelemetry/instrumentation-mysql2@0.45.0":
-  version "0.45.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz"
-  integrity sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==
-  dependencies:
-    "@opentelemetry/instrumentation" "^0.57.0"
-    "@opentelemetry/semantic-conventions" "^1.27.0"
-    "@opentelemetry/sql-common" "^0.40.1"
-
 "@opentelemetry/instrumentation-mysql@0.45.0":
   version "0.45.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.0.tgz"
@@ -1916,6 +1912,15 @@
     "@opentelemetry/instrumentation" "^0.57.0"
     "@opentelemetry/semantic-conventions" "^1.27.0"
     "@types/mysql" "2.15.26"
+
+"@opentelemetry/instrumentation-mysql2@0.45.0":
+  version "0.45.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz"
+  integrity sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.57.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+    "@opentelemetry/sql-common" "^0.40.1"
 
 "@opentelemetry/instrumentation-nestjs-core@0.44.0":
   version "0.44.0"
@@ -1963,18 +1968,6 @@
     "@opentelemetry/core" "^1.8.0"
     "@opentelemetry/instrumentation" "^0.57.0"
 
-"@opentelemetry/instrumentation@0.57.1":
-  version "0.57.1"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz"
-  integrity sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==
-  dependencies:
-    "@opentelemetry/api-logs" "0.57.1"
-    "@types/shimmer" "^1.2.0"
-    import-in-the-middle "^1.8.1"
-    require-in-the-middle "^7.1.1"
-    semver "^7.5.2"
-    shimmer "^1.2.1"
-
 "@opentelemetry/instrumentation@^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0":
   version "0.53.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz"
@@ -1999,12 +1992,24 @@
     semver "^7.5.2"
     shimmer "^1.2.1"
 
+"@opentelemetry/instrumentation@0.57.1":
+  version "0.57.1"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz"
+  integrity sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==
+  dependencies:
+    "@opentelemetry/api-logs" "0.57.1"
+    "@types/shimmer" "^1.2.0"
+    import-in-the-middle "^1.8.1"
+    require-in-the-middle "^7.1.1"
+    semver "^7.5.2"
+    shimmer "^1.2.1"
+
 "@opentelemetry/redis-common@^0.36.2":
   version "0.36.2"
   resolved "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz"
   integrity sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==
 
-"@opentelemetry/resources@1.30.1", "@opentelemetry/resources@^1.30.1":
+"@opentelemetry/resources@^1.30.1", "@opentelemetry/resources@1.30.1":
   version "1.30.1"
   resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz"
   integrity sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==
@@ -2021,6 +2026,11 @@
     "@opentelemetry/resources" "1.30.1"
     "@opentelemetry/semantic-conventions" "1.28.0"
 
+"@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0":
+  version "1.31.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.31.0.tgz"
+  integrity sha512-cYJeP+6qN0UnBv1r09hXl0YorB8kXHv61BC0NUlBA8vxrylZ4/C8lnva3gd1E8n33DNYSaiGW+DuGoSt0QQ7Dw==
+
 "@opentelemetry/semantic-conventions@1.27.0":
   version "1.27.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz"
@@ -2030,11 +2040,6 @@
   version "1.28.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz"
   integrity sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==
-
-"@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0":
-  version "1.31.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.31.0.tgz"
-  integrity sha512-cYJeP+6qN0UnBv1r09hXl0YorB8kXHv61BC0NUlBA8vxrylZ4/C8lnva3gd1E8n33DNYSaiGW+DuGoSt0QQ7Dw==
 
 "@opentelemetry/sql-common@^0.40.1":
   version "0.40.1"
@@ -2350,7 +2355,7 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
-"@testing-library/dom@^10.4.0":
+"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.0", "@testing-library/dom@>=7.21.4":
   version "10.4.0"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz"
   integrity sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==
@@ -2408,7 +2413,7 @@
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz"
   integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
 
-"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
+"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14", "@types/babel__core@^7.1.9":
   version "7.1.19"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz"
   integrity sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==
@@ -2523,7 +2528,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hoist-non-react-statics@3", "@types/hoist-non-react-statics@^3.3.1":
+"@types/hoist-non-react-statics@^3.3.1", "@types/hoist-non-react-statics@3":
   version "3.3.5"
   resolved "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz"
   integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
@@ -2679,7 +2684,7 @@
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react@*", "@types/react@^18.3.11":
+"@types/react@*", "@types/react@^16.8 || ^17.0 || ^18.0", "@types/react@^18.0.0 || ^19.0.0", "@types/react@^18.3.11":
   version "18.3.20"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz"
   integrity sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==
@@ -2807,7 +2812,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.5.0":
+"@typescript-eslint/eslint-plugin@^4.0.0 || ^5.0.0", "@typescript-eslint/eslint-plugin@^5.5.0":
   version "5.62.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz"
   integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
@@ -2830,7 +2835,7 @@
   dependencies:
     "@typescript-eslint/utils" "5.62.0"
 
-"@typescript-eslint/parser@^5.5.0":
+"@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@^5.5.0":
   version "5.62.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz"
   integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
@@ -2876,7 +2881,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.58.0":
+"@typescript-eslint/utils@^5.58.0", "@typescript-eslint/utils@5.62.0":
   version "5.62.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz"
   integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
@@ -2903,7 +2908,7 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
+"@webassemblyjs/ast@^1.14.1", "@webassemblyjs/ast@1.14.1":
   version "1.14.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz"
   integrity sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==
@@ -3004,7 +3009,7 @@
     "@webassemblyjs/wasm-gen" "1.14.1"
     "@webassemblyjs/wasm-parser" "1.14.1"
 
-"@webassemblyjs/wasm-parser@1.14.1", "@webassemblyjs/wasm-parser@^1.14.1":
+"@webassemblyjs/wasm-parser@^1.14.1", "@webassemblyjs/wasm-parser@1.14.1":
   version "1.14.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz"
   integrity sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==
@@ -3075,15 +3080,15 @@ acorn-walk@^7.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8, acorn@^8.14.0, acorn@^8.2.4, acorn@^8.8.2, acorn@^8.9.0:
+  version "8.14.1"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz"
+  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
+
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn@^8.14.0, acorn@^8.2.4, acorn@^8.8.2, acorn@^8.9.0:
-  version "8.14.1"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz"
-  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
 
 address@^1.0.1, address@^1.1.2:
   version "1.2.2"
@@ -3124,7 +3129,7 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.9.1:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3134,7 +3139,17 @@ ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.6.0, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.8.2, ajv@^8.9.0:
+  version "8.17.1"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
+ajv@^8.6.0, ajv@>=8:
   version "8.17.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
@@ -3220,7 +3235,7 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-query@5.3.0, aria-query@^5.0.0:
+aria-query@^5.0.0, aria-query@5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz"
   integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
@@ -3652,7 +3667,7 @@ bluebird@^3.7.2:
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-body-parser@1.20.3, body-parser@^1.20.3:
+body-parser@^1.20.3, body-parser@1.20.3:
   version "1.20.3"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz"
   integrity sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==
@@ -3685,7 +3700,7 @@ boolbase@^1.0.0, boolbase@~1.0.0:
 
 bottleneck@^2.19.5:
   version "2.19.5"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  resolved "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz"
   integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
 brace-expansion@^1.1.7:
@@ -3715,7 +3730,7 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.0.0, browserslist@^4.18.1, browserslist@^4.20.2, browserslist@^4.21.4, browserslist@^4.24.0, browserslist@^4.24.4:
+browserslist@^4.0.0, browserslist@^4.18.1, browserslist@^4.20.2, browserslist@^4.21.4, browserslist@^4.24.0, browserslist@^4.24.4, "browserslist@>= 4", "browserslist@>= 4.21.0", browserslist@>=4:
   version "4.24.4"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz"
   integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
@@ -3848,7 +3863,16 @@ case-sensitive-paths-webpack-plugin@^2.4.0:
   resolved "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz"
   integrity sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==
 
-chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.4.1:
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3990,6 +4014,11 @@ clone@^1.0.2:
   resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
@@ -4023,15 +4052,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 colord@^2.9.1:
   version "2.9.3"
@@ -4329,20 +4358,20 @@ css-select@^4.1.3:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
-css-tree@1.0.0-alpha.37:
-  version "1.0.0-alpha.37"
-  resolved "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz"
-  integrity sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==
-  dependencies:
-    mdn-data "2.0.4"
-    source-map "^0.6.1"
-
 css-tree@^1.1.2, css-tree@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz"
   integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
   dependencies:
     mdn-data "2.0.14"
+    source-map "^0.6.1"
+
+css-tree@1.0.0-alpha.37:
+  version "1.0.0-alpha.37"
+  resolved "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz"
+  integrity sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==
+  dependencies:
+    mdn-data "2.0.4"
     source-map "^0.6.1"
 
 css-what@^3.2.1:
@@ -4489,7 +4518,7 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns@^2.29.3:
+date-fns@^2.28.0, date-fns@^2.29.3:
   version "2.29.3"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
@@ -4506,19 +4535,12 @@ dayjs@^1.11.9:
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
-debug@2.6.9, debug@^2.6.0:
+debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@4, debug@^4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
-  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
-  dependencies:
-    ms "^2.1.3"
 
 debug@^3.2.7:
   version "3.2.7"
@@ -4526,6 +4548,20 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@4:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+  dependencies:
+    ms "^2.1.3"
+
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 decamelize-keys@^1.1.0:
   version "1.1.1"
@@ -4607,15 +4643,20 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
+
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 dequal@^2.0.3:
   version "2.0.3"
@@ -4705,14 +4746,6 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-serializer@0:
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz"
-  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
-  dependencies:
-    domelementtype "^2.0.1"
-    entities "^2.0.0"
-
 dom-serializer@^1.0.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz"
@@ -4722,15 +4755,23 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
-domelementtype@1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz"
-  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+dom-serializer@0:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
 
 domelementtype@^2.0.1, domelementtype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domelementtype@1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -4874,7 +4915,7 @@ entities@^2.0.0:
 
 env-paths@^2.2.0:
   version "2.2.1"
-  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  resolved "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 error-ex@^1.3.1:
@@ -5204,7 +5245,7 @@ eslint-plugin-testing-library@^5.0.1:
   dependencies:
     "@typescript-eslint/utils" "^5.58.0"
 
-eslint-scope@5.1.1, eslint-scope@^5.1.1:
+eslint-scope@^5.1.1, eslint-scope@5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -5241,7 +5282,7 @@ eslint-webpack-plugin@^3.1.1:
     normalize-path "^3.0.0"
     schema-utils "^4.0.0"
 
-eslint@^8.3.0:
+eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "eslint@^6.0.0 || ^7.0.0 || ^8.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.0.0 || ^8.0.0", "eslint@^7.5.0 || ^8.0.0", eslint@^8.0.0, eslint@^8.1.0, eslint@^8.3.0, "eslint@>= 6":
   version "8.57.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -5294,15 +5335,15 @@ espree@^9.6.0, espree@^9.6.1:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esprima@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
-  integrity sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==
-
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esprima@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+  integrity sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==
 
 esquery@^1.4.2:
   version "1.6.0"
@@ -5318,7 +5359,12 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -5555,12 +5601,12 @@ filter-obj@^1.1.0:
   resolved "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz"
   integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
 
-final-form-arrays@3.1.0:
+final-form-arrays@>=1.0.4, final-form-arrays@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.1.0.tgz"
   integrity sha512-TWBvun+AopgBLw9zfTFHBllnKMVNEwCEyDawphPuBGGqNsuhGzhT7yewHys64KFFwzIs6KEteGLpKOwvTQEscQ==
 
-final-form@4.20.10:
+final-form@^4.15.0, final-form@^4.20.4, final-form@^4.20.8, final-form@4.20.10:
   version "4.20.10"
   resolved "https://registry.npmjs.org/final-form/-/final-form-4.20.10.tgz"
   integrity sha512-TL48Pi1oNHeMOHrKv1bCJUrWZDcD3DIG6AGYVNOnyZPr7Bd/pStN0pL+lfzF5BNoj/FclaoiaLenk4XUIFVYng==
@@ -6051,7 +6097,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hoist-non-react-statics@3, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2, hoist-non-react-statics@3:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6141,6 +6187,16 @@ http-deceiver@^1.2.7:
   resolved "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz"
   integrity sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==
 
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
+  integrity sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
 http-errors@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz"
@@ -6151,16 +6207,6 @@ http-errors@2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
-
-http-errors@~1.6.2:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
-  integrity sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
 
 http-parser-js@>=0.5.1:
   version "0.5.10"
@@ -6209,7 +6255,7 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@^0.4.24, iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6304,7 +6350,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -6371,15 +6417,30 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ipaddr.js@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
-  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+ioredis@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz"
+  integrity sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==
+  dependencies:
+    "@ioredis/commands" "^1.3.0"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
 
 ipaddr.js@^2.0.1:
   version "2.2.0"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz"
   integrity sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-alphabetical@^1.0.0:
   version "1.0.4"
@@ -6685,11 +6746,6 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
-
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz"
@@ -6699,6 +6755,11 @@ isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -7081,7 +7142,7 @@ jest-resolve-dependencies@^27.5.1:
     jest-regex-util "^27.5.1"
     jest-snapshot "^27.5.1"
 
-jest-resolve@^27.4.2, jest-resolve@^27.5.1:
+jest-resolve@*, jest-resolve@^27.4.2, jest-resolve@^27.5.1:
   version "27.5.1"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.5.1.tgz"
   integrity sha512-FFDy8/9E6CV83IMbDpcjOhumAQPDyETnU2KZ1O98DwTnz8AOBsW/Xv3GySr1mOZdItLR+zDZ7I/UdTFbgSOVCw==
@@ -7303,7 +7364,7 @@ jest-worker@^28.0.2:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^27.4.3:
+"jest@^27.0.0 || ^28.0.0", jest@^27.4.3:
   version "27.5.1"
   resolved "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz"
   integrity sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==
@@ -7645,10 +7706,20 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
   integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -7910,15 +7981,15 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
 "mime-db@>= 1.43.0 < 2":
   version "1.54.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.35, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
@@ -8014,20 +8085,20 @@ moment-timezone@^0.5.48:
   dependencies:
     moment "^2.29.4"
 
-moment@>=1.6.0, moment@^2.29.4, moment@^2.30.1:
+moment@^2.29.4, moment@^2.30.1, moment@>=1.6.0:
   version "2.30.1"
   resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
+ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
-ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multicast-dns@^7.2.5:
   version "7.2.5"
@@ -8066,15 +8137,15 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-negotiator@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
-  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
 negotiator@~0.6.4:
   version "0.6.4"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.6.2:
   version "2.6.2"
@@ -8491,6 +8562,14 @@ passport-facebook@^3.0.0:
   dependencies:
     passport-oauth2 "1.x.x"
 
+passport-google-oauth@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/passport-google-oauth/-/passport-google-oauth-2.0.0.tgz"
+  integrity sha512-JKxZpBx6wBQXX1/a1s7VmdBgwOugohH+IxCy84aPTZNq/iIPX6u7Mqov1zY7MKRz3niFPol0KJz8zPLBoHKtYA==
+  dependencies:
+    passport-google-oauth1 "1.x.x"
+    passport-google-oauth20 "2.x.x"
+
 passport-google-oauth1@1.x.x:
   version "1.0.0"
   resolved "https://registry.npmjs.org/passport-google-oauth1/-/passport-google-oauth1-1.0.0.tgz"
@@ -8504,14 +8583,6 @@ passport-google-oauth20@2.x.x:
   integrity sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==
   dependencies:
     passport-oauth2 "1.x.x"
-
-passport-google-oauth@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/passport-google-oauth/-/passport-google-oauth-2.0.0.tgz"
-  integrity sha512-JKxZpBx6wBQXX1/a1s7VmdBgwOugohH+IxCy84aPTZNq/iIPX6u7Mqov1zY7MKRz3niFPol0KJz8zPLBoHKtYA==
-  dependencies:
-    passport-google-oauth1 "1.x.x"
-    passport-google-oauth20 "2.x.x"
 
 passport-oauth1@1.x.x:
   version "1.3.0"
@@ -8601,11 +8672,6 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.12:
-  version "0.1.12"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz"
-  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
-
 path-to-regexp@^1.7.0:
   version "1.9.0"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz"
@@ -8617,6 +8683,11 @@ path-to-regexp@^8.2.0:
   version "8.2.0"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz"
   integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
+
+path-to-regexp@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz"
+  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -8868,19 +8939,19 @@ postcss-image-set-function@^4.0.7:
   dependencies:
     postcss-value-parser "^4.2.0"
 
-postcss-import@14.1.0:
-  version "14.1.0"
-  resolved "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz"
-  integrity sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==
+postcss-import@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz"
+  integrity sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==
   dependencies:
     postcss-value-parser "^4.0.0"
     read-cache "^1.0.0"
     resolve "^1.1.7"
 
-postcss-import@^15.1.0:
-  version "15.1.0"
-  resolved "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz"
-  integrity sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==
+postcss-import@14.1.0:
+  version "14.1.0"
+  resolved "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz"
+  integrity sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==
   dependencies:
     postcss-value-parser "^4.0.0"
     read-cache "^1.0.0"
@@ -9255,15 +9326,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^7.0.35:
-  version "7.0.39"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz"
-  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
-  dependencies:
-    picocolors "^0.2.1"
-    source-map "^0.6.1"
-
-postcss@^8.3.5, postcss@^8.4.33, postcss@^8.4.4, postcss@^8.4.47:
+"postcss@^7.0.0 || ^8.0.1", postcss@^8, postcss@^8.0.0, postcss@^8.0.3, postcss@^8.0.9, postcss@^8.1.0, postcss@^8.1.4, postcss@^8.2, postcss@^8.2.14, postcss@^8.2.15, postcss@^8.2.2, postcss@^8.3, postcss@^8.3.5, postcss@^8.4, postcss@^8.4.21, postcss@^8.4.33, postcss@^8.4.4, postcss@^8.4.47, postcss@^8.4.6, "postcss@>= 8", postcss@>=8, postcss@>=8.0.9:
   version "8.5.3"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz"
   integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
@@ -9271,6 +9334,14 @@ postcss@^8.3.5, postcss@^8.4.33, postcss@^8.4.4, postcss@^8.4.47:
     nanoid "^3.3.8"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+postcss@^7.0.35:
+  version "7.0.39"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+  dependencies:
+    picocolors "^0.2.1"
+    source-map "^0.6.1"
 
 postgres-array@~2.0.0:
   version "2.0.0"
@@ -9426,7 +9497,7 @@ q@^1.1.2:
   resolved "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
-qs@6.13.0, qs@^6.9.4:
+qs@^6.9.4, qs@6.13.0:
   version "6.13.0"
   resolved "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz"
   integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
@@ -9534,7 +9605,7 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-react-dom@^18.3.1:
+"react-dom@^16.8 || ^17.0 || ^18.0", "react-dom@^18.0.0 || ^19.0.0", react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -9559,7 +9630,7 @@ react-final-form-arrays@3.1.4:
   dependencies:
     "@babel/runtime" "^7.19.4"
 
-react-final-form@6.5.9:
+react-final-form@^6.2.1, react-final-form@6.5.9:
   version "6.5.9"
   resolved "https://registry.npmjs.org/react-final-form/-/react-final-form-6.5.9.tgz"
   integrity sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==
@@ -9630,7 +9701,7 @@ react-redux@^8.1.2:
     react-is "^18.0.0"
     use-sync-external-store "^1.0.0"
 
-react-refresh@^0.11.0:
+react-refresh@^0.11.0, "react-refresh@>=0.10.0 <1.0.0":
   version "0.11.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
@@ -9663,7 +9734,7 @@ react-router@5.3.4:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react@^18.3.1:
+"react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.3.0 || ^17.0.0 || ^18.0.0", "react@^16.6.0 || ^17.0.0 || ^18.0.0", "react@^16.6.0 || 17 || 18", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0", react@^18.3.1, "react@>= 16", react@>=15:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
@@ -9740,12 +9811,24 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 redux-thunk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz"
   integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
 
-redux@^4.2.1:
+redux@^4, "redux@^4 || ^5.0.0-beta.0", redux@^4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz"
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
@@ -9998,7 +10081,7 @@ rollup-plugin-terser@^7.0.0:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.43.1:
+"rollup@^1.20.0 || ^2.0.0", rollup@^1.20.0||^2.0.0, rollup@^2.0.0, rollup@^2.43.1:
   version "2.79.2"
   resolved "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz"
   integrity sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==
@@ -10035,12 +10118,17 @@ safe-array-concat@^1.1.2, safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@>=5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1, safe-buffer@5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1, safe-buffer@~5.2.0:
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -10104,15 +10192,6 @@ scheduler@^0.23.2:
   dependencies:
     loose-envify "^1.1.0"
 
-schema-utils@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz"
-  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
-  dependencies:
-    "@types/json-schema" "^7.0.4"
-    ajv "^6.12.2"
-    ajv-keywords "^3.4.1"
-
 schema-utils@^2.6.5:
   version "2.7.1"
   resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz"
@@ -10141,6 +10220,15 @@ schema-utils@^4.0.0, schema-utils@^4.3.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
 
+schema-utils@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz"
+  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
+  dependencies:
+    "@types/json-schema" "^7.0.4"
+    ajv "^6.12.2"
+    ajv-keywords "^3.4.1"
+
 scmp@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz"
@@ -10164,12 +10252,32 @@ selfsigned@^2.1.1:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.1:
+semver@^5.5.1:
   version "5.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^6.3.1:
+semver@^6.0.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.1.1:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.1.2:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -10178,6 +10286,11 @@ semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semve
   version "7.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
+"semver@2 || 3 || 4 || 5":
+  version "5.7.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 send@0.19.0:
   version "0.19.0"
@@ -10283,7 +10396,7 @@ shallowequal@^1.1.0:
 
 sharetribe-flex-integration-sdk@^1.11.0:
   version "1.11.0"
-  resolved "https://registry.yarnpkg.com/sharetribe-flex-integration-sdk/-/sharetribe-flex-integration-sdk-1.11.0.tgz#b1a967e5416cd8fd9006a84c248f29c06b7529ee"
+  resolved "https://registry.npmjs.org/sharetribe-flex-integration-sdk/-/sharetribe-flex-integration-sdk-1.11.0.tgz"
   integrity sha512-oZuiX5u3nDaWinafdEf7c+CdhGyRvpMWuiBrTyXnqt8WpgxiqW1E3PHE3VJvGclW7rVcdZOZVXbZnWQGe1rzHw==
   dependencies:
     axios "^1.5.1"
@@ -10518,7 +10631,7 @@ source-map-support@^0.5.21, source-map-support@^0.5.6, source-map-support@~0.5.2
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1, source-map@0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -10626,6 +10739,11 @@ stackframe@^1.3.4:
   resolved "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz"
   integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
 
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
+
 static-eval@2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz"
@@ -10633,20 +10751,34 @@ static-eval@2.0.2:
   dependencies:
     escodegen "^1.8.1"
 
-statuses@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
-  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
-
 "statuses@>= 1.4.0 < 2":
   version "1.5.0"
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
 strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -10764,20 +10896,6 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
-
 stringify-object@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz"
@@ -10873,7 +10991,14 @@ sucrase@^3.35.0:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
-supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -10887,7 +11012,14 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0, supports-color@^8.1.1:
+supports-color@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -11182,15 +11314,15 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2, tslib@^2.0.3, tslib@^2.1.0:
-  version "2.8.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.3, tslib@^2.1.0, tslib@2:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -11212,7 +11344,7 @@ twilio@^5.7.1:
     scmp "^2.1.0"
     xmlbuilder "^13.0.2"
 
-type-check@^0.4.0, type-check@~0.4.0:
+type-check@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
@@ -11226,6 +11358,13 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
 type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
@@ -11236,7 +11375,7 @@ type-fest@^0.16.0:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz"
   integrity sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==
 
-type-fest@^0.18.0:
+type-fest@^0.18.0, "type-fest@>=0.17.0 <3.0.0":
   version "0.18.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz"
   integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
@@ -11320,6 +11459,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+"typescript@^3.2.1 || ^4", "typescript@^4.7 || 5", "typescript@>= 2.7", "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta":
+  version "4.9.5"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uid2@0.0.x:
   version "0.0.4"
@@ -11466,7 +11610,7 @@ universalify@^2.0.0:
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
-unpipe@1.0.0, unpipe@~1.0.0:
+unpipe@~1.0.0, unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
@@ -11529,7 +11673,7 @@ utila@~0.4:
   resolved "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
 
-utils-merge@1.0.1, utils-merge@1.x.x, utils-merge@^1.0.1:
+utils-merge@^1.0.1, utils-merge@1.0.1, utils-merge@1.x.x:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
@@ -11658,7 +11802,7 @@ webpack-dev-middleware@^5.3.4:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.6.0:
+webpack-dev-server@^4.6.0, "webpack-dev-server@3.x || 4.x":
   version "4.15.2"
   resolved "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz"
   integrity sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==
@@ -11728,7 +11872,7 @@ webpack-sources@^3.2.3:
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.64.4:
+"webpack@^4.0.0 || ^5.0.0", "webpack@^4.37.0 || ^5.0.0", "webpack@^4.4.0 || ^5.9.0", "webpack@^4.44.2 || ^5.47.0", webpack@^5.0.0, webpack@^5.1.0, webpack@^5.20.0, webpack@^5.64.4, "webpack@>= 4", webpack@>=2, "webpack@>=4.43.0 <6.0.0", webpack@>=4.6.0:
   version "5.99.5"
   resolved "https://registry.npmjs.org/webpack/-/webpack-5.99.5.tgz"
   integrity sha512-q+vHBa6H9qwBLUlHL4Y7L0L1/LlyBKZtS9FHNCQmtayxjI5RKC9yD8gpvLeqGv5lCQp1Re04yi0MF40pf30Pvg==
@@ -11757,7 +11901,7 @@ webpack@^5.64.4:
     watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
-websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
+websocket-driver@^0.7.4, websocket-driver@>=0.5.1:
   version "0.7.4"
   resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz"
   integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
@@ -12110,7 +12254,7 @@ ws@^8.13.0:
 
 xdg-basedir@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
+  resolved "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
 xml-name-validator@^3.0.0:
@@ -12148,7 +12292,12 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.2.2, yaml@^2.3.4:
+yaml@^2.2.2:
+  version "2.7.1"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz"
+  integrity sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==
+
+yaml@^2.3.4:
   version "2.7.1"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz"
   integrity sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==


### PR DESCRIPTION
## Summary
Adds the full “Lender shipping label/QR” SMS flow **without** introducing a QR cache. 
This builds on the earlier SMS hardening + request/accept texts.

## What’s included
- ✉️ Sends shipping SMS to the **lender** with:
  - Short branded QR link and label URL
  - Carrier-friendly copy and Twilio Delivery Receipt (DLR) tracking
- 📦 Shippo integration flow fixes:
  - Proper label creation sequence and error handling
  - Persistence of label/QR URLs in `protectedData`
  - Reduced 409s and better retry behavior
- 🔗 Branded short-link + QR route:
  - `/api/qr/:id` (moved under `/api` to avoid SPA 404s)
  - Cache-Control + robots headers
  - Debug endpoints gated behind env checks; limited `protectedData` exposure
- 🛡️ Infra tweaks used by the above:
  - CSP/CORS adjustments
  - Small resilience helpers used by Shippo/SMS paths

> **Not included:** QR delivery cache (no Redis / in-memory TTL). We’ll decide that in a separate PR.

## Why
Enable lender shipping notifications and a clean QR experience now, while keeping deployment simple (no new infra like Redis).

## Deployment notes
- Uses the same Shippo/Twilio creds already present in **test**. Ensure the equivalent env vars exist in **prod**.
- Twilio DLR hits the new `POST /api/twilio/sms-status` endpoint.
- No front-end `REACT_APP_*` changes required.
- No new feature flags required for this tranche. Keep prior flags for request/accept SMS as configured.

## How to test (prod after merge)
1. Create a test transaction that triggers label creation.
2. Confirm:
   - Lender receives SMS with short QR link + label.
   - `/api/qr/:id` resolves and shows the correct content.
   - `protectedData` contains persisted label/QR URLs.
   - DLRs arrive at `POST /api/twilio/sms-status` (logs show status updates).
3. (Optional) Use the gated QR debug endpoints to verify wiring if needed.

## Rollback
Revert this PR. No data migrations; persisted `protectedData` keys are harmless if left behind.

## Follow-ups
- PR #3: choose **one** QR delivery cache strategy:
  - In-memory TTL (simple), or
  - Redis (matches test).
