### PR TITLE
feat(ui): add AddressForm assets (unwired, no behavior change)

### DIFF
--- a/src/components/AddressForm/AddressForm.js
+++ b/src/components/AddressForm/AddressForm.js
@@ -1,0 +1,230 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { Field, useFormState } from 'react-final-form';
+import FieldTextInput from '../FieldTextInput/FieldTextInput';
+import FieldSelect from '../FieldSelect/FieldSelect';
+import css from './AddressForm.module.css';
+import { US_STATES, CA_PROVINCES } from '../../util/geoData';
+
+// Country options with ISO-2 codes
+const COUNTRY_OPTIONS = [
+  { label: 'United States', value: 'US' },
+  { label: 'Canada', value: 'CA' },
+  { label: 'Mexico', value: 'MX' },
+  { label: 'United Kingdom', value: 'GB' },
+  { label: 'Germany', value: 'DE' },
+  { label: 'France', value: 'FR' },
+  { label: 'Italy', value: 'IT' },
+  { label: 'Spain', value: 'ES' },
+  { label: 'Australia', value: 'AU' },
+  { label: 'Japan', value: 'JP' },
+  { label: 'China', value: 'CN' },
+  { label: 'India', value: 'IN' },
+  { label: 'Brazil', value: 'BR' },
+  { label: 'Argentina', value: 'AR' },
+  { label: 'Chile', value: 'CL' },
+  { label: 'Colombia', value: 'CO' },
+  { label: 'Peru', value: 'PE' },
+  { label: 'Venezuela', value: 'VE' },
+  { label: 'Ecuador', value: 'EC' },
+  { label: 'Uruguay', value: 'UY' },
+  { label: 'Paraguay', value: 'PY' },
+  { label: 'Bolivia', value: 'BO' },
+  { label: 'Guyana', value: 'GY' },
+  { label: 'Suriname', value: 'SR' },
+  { label: 'Falkland Islands', value: 'FK' },
+];
+
+export default function AddressForm({
+  namespace,
+  title,
+  requiredFields = {},
+  disabled = false,
+  countryAfterZipForUSCA = true,
+}) {
+  // Guard: prevent nameless <Field> crash
+  if (!namespace) {
+    /* eslint-disable no-console */
+    console.error('[AddressForm] namespace prop is required ("billing" or "shipping").');
+    return null;
+  }
+
+  const { values } = useFormState({ subscription: { values: true } });
+  const cfg = useMemo(() => {
+    const c = (values?.[namespace]?.country || 'US').toUpperCase();
+    const isUS = c === 'US';
+    const isCA = c === 'CA';
+    return {
+      country: c,
+      isUS,
+      isCA,
+      stateLabel: isUS ? 'State' : isCA ? 'Province' : 'State / Region',
+      postalLabel: isUS ? 'ZIP Code' : 'Postal Code',
+      stateRequired: !!requiredFields.state && (isUS || isCA),
+      postalRequired: !!requiredFields.postalCode,
+      placeCountryAfterZip: countryAfterZipForUSCA && (isUS || isCA),
+      stateOptions: isUS ? US_STATES : isCA ? CA_PROVINCES : null,
+    };
+  }, [values, namespace, requiredFields.state, requiredFields.postalCode, countryAfterZipForUSCA]);
+
+  return (
+    <div className={css.root} aria-disabled={disabled}>
+      {title ? <h3 className={css.title}>{title}</h3> : null}
+      
+      {/* Full name */}
+      <FieldTextInput
+        className={css.field}
+        id={`${namespace}-name`}
+        name={`${namespace}.name`}
+        label="Full Name"
+        required={!!requiredFields.name}
+        autoComplete="name"
+        disabled={disabled}
+        key={`${namespace}-name`}
+      />
+
+      {/* Street line 1 */}
+      <FieldTextInput
+        className={css.field}
+        id={`${namespace}-line1`}
+        name={`${namespace}.line1`}
+        label="Street Address"
+        placeholder="123 Example Street"
+        required={!!requiredFields.line1}
+        autoComplete="address-line1"
+        disabled={disabled}
+      />
+
+      {/* Street line 2 */}
+      <FieldTextInput
+        className={css.field}
+        id={`${namespace}-line2`}
+        name={`${namespace}.line2`}
+        label="Apartment, Suite, etc. (Optional)"
+        placeholder="Apt / Suite (optional)"
+        required={false}
+        autoComplete="address-line2"
+        disabled={disabled}
+      />
+
+      {/* City */}
+      <FieldTextInput
+        className={css.field}
+        id={`${namespace}-city`}
+        name={`${namespace}.city`}
+        label="City"
+        required={!!requiredFields.city}
+        autoComplete="address-level2"
+        disabled={disabled}
+      />
+
+      {/* Country BEFORE state for non-US/CA (so state rules can react) */}
+      {!cfg.placeCountryAfterZip && (
+        <FieldSelect
+          className={css.field}
+          id={`${namespace}-country`}
+          name={`${namespace}.country`}
+          label="Country"
+          required={!!requiredFields.country}
+          autoComplete="country"
+          disabled={disabled}
+        >
+          <option value="" disabled>Select a country</option>
+          {COUNTRY_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </FieldSelect>
+      )}
+
+      {/* State / Region (dropdown for US/CA, input otherwise) */}
+      {cfg.stateOptions ? (
+        <FieldSelect
+          className={css.field}
+          id={`${namespace}-state`}
+          name={`${namespace}.state`}
+          label={cfg.stateLabel}
+          required={cfg.stateRequired}
+          autoComplete="address-level1"
+          disabled={disabled}
+        >
+          <option value="" disabled>Select a {cfg.stateLabel.toLowerCase()}</option>
+          {cfg.stateOptions.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </FieldSelect>
+      ) : (
+        <FieldTextInput
+          className={css.field}
+          id={`${namespace}-state`}
+          name={`${namespace}.state`}
+          label={cfg.stateLabel}
+          required={cfg.stateRequired}
+          autoComplete="address-level1"
+          disabled={disabled}
+        />
+      )}
+
+      {/* ZIP / Postal */}
+      <FieldTextInput
+        className={css.field}
+        id={`${namespace}-postalCode`}
+        name={`${namespace}.postalCode`}
+        label={cfg.postalLabel}
+        required={!!requiredFields.postalCode}
+        autoComplete="postal-code"
+        disabled={disabled}
+      />
+
+      {/* Country AFTER ZIP for US/CA */}
+      {cfg.placeCountryAfterZip && (
+        <FieldSelect
+          className={css.field}
+          id={`${namespace}-country`}
+          name={`${namespace}.country`}
+          label="Country"
+          required={!!requiredFields.country}
+          autoComplete="country"
+          disabled={disabled}
+        >
+          <option value="" disabled>Select a country</option>
+          {COUNTRY_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </FieldSelect>
+      )}
+
+      {/* Email */}
+      <FieldTextInput
+        className={css.field}
+        id={`${namespace}-email`}
+        name={`${namespace}.email`}
+        label="Email Address"
+        type="email"
+        required={!!requiredFields.email}
+        autoComplete="email"
+        disabled={disabled}
+      />
+
+      {/* Phone */}
+      <FieldTextInput
+        className={css.field}
+        id={`${namespace}-phone`}
+        name={`${namespace}.phone`}
+        label="Phone Number"
+        type="tel"
+        required={!!requiredFields.phone}
+        autoComplete="tel"
+        disabled={disabled}
+      />
+
+    </div>
+  );
+}
+
+AddressForm.propTypes = {
+  namespace: PropTypes.oneOf(['billing', 'shipping']).isRequired,
+  title: PropTypes.string,
+  requiredFields: PropTypes.object,
+  disabled: PropTypes.bool,
+  countryAfterZipForUSCA: PropTypes.bool,
+};

--- a/src/components/AddressForm/AddressForm.module.css
+++ b/src/components/AddressForm/AddressForm.module.css
@@ -1,0 +1,102 @@
+.root {
+  margin-bottom: 28px;
+}
+
+.title {
+  margin: 0 0 16px;
+  font-weight: 600;
+}
+
+.fieldRow {
+  margin-bottom: 16px;
+}
+
+.field {
+  /* space below each input */
+  margin-bottom: 14px;
+  position: relative;
+  overflow: visible; /* allow native dropdown to render */
+}
+
+.field select,
+.field input {
+  position: relative;
+  z-index: 1;
+  pointer-events: auto;
+}
+
+.field label {
+  position: static; /* avoid absolute labels covering the control */
+}
+
+.field::after {
+  /* If there is any decorative overlay, disable pointer interception */
+  pointer-events: none;
+}
+
+.sameAs {
+  margin-top: 8px;
+}
+
+.checkboxLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+}
+
+.checkbox {
+  width: 16px;
+  height: 16px;
+}
+
+/* Responsive layout for address fields */
+@media (min-width: 768px) {
+  .fieldRow:nth-child(3), /* Street 1 */
+  .fieldRow:nth-child(4), /* Street 2 */
+  .fieldRow:nth-child(5), /* City */
+  .fieldRow:nth-child(6), /* State */
+  .fieldRow:nth-child(7), /* ZIP */
+  .fieldRow:nth-child(8), /* Email */
+  .fieldRow:nth-child(9) { /* Phone */
+    display: flex;
+    gap: 16px;
+  }
+  
+  .fieldRow:nth-child(5) .field, /* City */
+  .fieldRow:nth-child(6) .field, /* State */
+  .fieldRow:nth-child(7) .field { /* ZIP */
+    flex: 1;
+  }
+  
+  .fieldRow:nth-child(8) .field, /* Email */
+  .fieldRow:nth-child(9) .field { /* Phone */
+    flex: 1;
+  }
+}
+
+/* Disabled state styling */
+.field input:disabled,
+.field select:disabled {
+  background-color: #f8f9fa;
+  color: #6c757d;
+  cursor: not-allowed;
+}
+
+/* Error state styling */
+.field input.error,
+.field select.error {
+  border-color: #dc3545;
+}
+
+.field .error {
+  color: #dc3545;
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+/* Required field indicator */
+.field label.required::after {
+  content: ' *';
+  color: #dc3545;
+}

--- a/src/util/addressHelpers.js
+++ b/src/util/addressHelpers.js
@@ -1,0 +1,213 @@
+/**
+ * Address normalization and mapping utilities
+ */
+
+// Normalize address data by trimming spaces and converting to standard formats
+export const normalizeAddress = (address) => {
+  if (!address) return null;
+
+  const normalized = {
+    fullName: address.fullName?.trim().replace(/\s+/g, ' ') || '',
+    country: address.country?.toUpperCase() || 'US',
+    street1: address.street1?.trim().replace(/\s+/g, ' ') || '',
+    street2: address.street2?.trim().replace(/\s+/g, ' ') || undefined, // Always send undefined when missing
+    city: address.city?.trim().replace(/\s+/g, ' ') || '',
+    state: address.state?.trim().toUpperCase() || '',
+    zip: address.zip?.trim().replace(/\s+/g, '') || '',
+    email: address.email?.trim().toLowerCase() || '',
+    phone: normalizePhone(address.phone) || '',
+  };
+
+  // Clean up empty strings to undefined for optional fields
+  if (!normalized.street2) normalized.street2 = undefined;
+  if (!normalized.phone) normalized.phone = undefined;
+
+  return normalized;
+};
+
+// Normalize phone number to E.164 format
+export const normalizePhone = (phone) => {
+  if (!phone) return '';
+  
+  // Remove extensions (x123, ext 123, etc.) and reject them
+  let cleaned = phone.replace(/\s*(x|ext|extension)\s*\d+.*$/i, '');
+  
+  // Remove all non-digit characters except +
+  cleaned = cleaned.replace(/[^\d+]/g, '');
+  
+  // If it doesn't start with +, assume US number and add +1
+  if (!cleaned.startsWith('+')) {
+    // Remove leading 1 if present
+    if (cleaned.startsWith('1') && cleaned.length === 11) {
+      cleaned = cleaned.substring(1);
+    }
+    cleaned = '+1' + cleaned;
+  }
+  
+  // Validate E.164 format (1-15 digits after +)
+  const e164Regex = /^\+[1-9]\d{1,14}$/;
+  if (!e164Regex.test(cleaned)) {
+    return phone; // Return original if normalization fails
+  }
+  
+  return cleaned;
+};
+
+// Map normalized address to Stripe billing format
+export const mapToStripeBilling = (address) => {
+  const normalized = normalizeAddress(address);
+  if (!normalized) return null;
+
+  return {
+    name: normalized.fullName,
+    email: normalized.email,
+    phone: normalized.phone,
+    address: {
+      line1: normalized.street1,
+      line2: normalized.street2 || undefined, // Always send undefined when missing
+      city: normalized.city,
+      state: normalized.state,
+      postal_code: normalized.zip,
+      country: normalized.country,
+    },
+  };
+};
+
+// Map normalized address to Shippo/UPS/FedEx format
+export const mapToShippo = (address) => {
+  const normalized = normalizeAddress(address);
+  if (!normalized) return null;
+
+  return {
+    name: normalized.fullName,
+    email: normalized.email,
+    phone: normalized.phone,
+    street1: normalized.street1,
+    street2: normalized.street2 || '',
+    city: normalized.city,
+    state: normalized.state,
+    zip: normalized.zip,
+    country: normalized.country,
+  };
+};
+
+// Check if address is a PO Box (for courier routing)
+export const isPOBox = (address) => {
+  if (!address?.street1) return false;
+  return /^(P(OST)?\.?\s*O(FFICE)?\.?\s*BOX)\b/i.test(address.street1);
+};
+
+// Map normalized address to UPS format
+export const mapToUPS = (address) => {
+  const normalized = normalizeAddress(address);
+  if (!normalized) return null;
+
+  return {
+    name: normalized.fullName,
+    email: normalized.email,
+    phone: normalized.phone,
+    address_line1: normalized.street1,
+    address_line2: normalized.street2 || '',
+    city: normalized.city,
+    state_province_code: normalized.state,
+    postal_code: normalized.zip,
+    country_code: normalized.country,
+  };
+};
+
+// Map normalized address to FedEx format
+export const mapToFedEx = (address) => {
+  const normalized = normalizeAddress(address);
+  if (!normalized) return null;
+
+  return {
+    contact: {
+      person_name: normalized.fullName,
+      email_address: normalized.email,
+      phone_number: normalized.phone,
+    },
+    address: {
+      street_lines: [normalized.street1, normalized.street2].filter(Boolean),
+      city: normalized.city,
+      state_or_province_code: normalized.state,
+      postal_code: normalized.zip,
+      country_code: normalized.country,
+    },
+  };
+};
+
+// Validate address completeness
+export const validateAddress = (address, requiredFields = {}) => {
+  const defaults = {
+    fullName: true,
+    country: true,
+    street1: true,
+    city: true,
+    state: true,
+    zip: true,
+    email: true,
+    phone: false,
+  };
+  
+  const requirements = { ...defaults, ...requiredFields };
+  const errors = {};
+  
+  if (requirements.fullName && !address.fullName?.trim()) {
+    errors.fullName = 'Full name is required';
+  }
+  
+  if (requirements.country && !address.country?.trim()) {
+    errors.country = 'Country is required';
+  }
+  
+  if (requirements.street1 && !address.street1?.trim()) {
+    errors.street1 = 'Street address is required';
+  }
+  
+  if (requirements.city && !address.city?.trim()) {
+    errors.city = 'City is required';
+  }
+  
+  if (requirements.state && !address.state?.trim()) {
+    errors.state = 'State/Region is required';
+  }
+  
+  if (requirements.zip && !address.zip?.trim()) {
+    errors.zip = 'ZIP/Postal code is required';
+  }
+  
+  if (requirements.email && !address.email?.trim()) {
+    errors.email = 'Email is required';
+  } else if (address.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(address.email)) {
+    errors.email = 'Please enter a valid email address';
+  }
+  
+  if (requirements.phone && !address.phone?.trim()) {
+    errors.phone = 'Phone number is required';
+  }
+  
+  return {
+    isValid: Object.keys(errors).length === 0,
+    errors,
+  };
+};
+
+// Copy billing address to shipping address
+export const copyBillingToShipping = (billingAddress) => {
+  const normalized = normalizeAddress(billingAddress);
+  if (!normalized) return null;
+
+  return {
+    shipping: {
+      fullName: normalized.fullName,
+      country: normalized.country,
+      street1: normalized.street1,
+      street2: normalized.street2,
+      city: normalized.city,
+      state: normalized.state,
+      zip: normalized.zip,
+      email: normalized.email,
+      phone: normalized.phone,
+    },
+  };
+};


### PR DESCRIPTION
Adds AddressForm component, styles, and helpers to the codebase without wiring.
No imports or behavior changes yet; safe preparation for a gated checkout UI.
