### PR TITLE
feat(ui): conditionally render AddressForm behind REACT_APP_CHECKOUT_ADDR_ENABLED (read-only, no payload changes)

### DIFF
--- a/src/containers/CheckoutPage/StripePaymentForm/StripePaymentForm.js
+++ b/src/containers/CheckoutPage/StripePaymentForm/StripePaymentForm.js
@@ -24,8 +24,11 @@ import {
 } from '../../../components';
 
 import ShippingDetails from '../ShippingDetails/ShippingDetails';
+import AddressForm from '../../../components/AddressForm/AddressForm';
 
 import css from './StripePaymentForm.module.css';
+
+const CHECKOUT_ADDR_ENABLED = process.env.REACT_APP_CHECKOUT_ADDR_ENABLED === 'true';
 
 /**
  * Translate a Stripe API error object.
@@ -566,6 +569,12 @@ function StripePaymentForm(props) {
                 />
 
                 {billingAddress}
+
+                {CHECKOUT_ADDR_ENABLED && (
+                  <section data-test="address-form-experimental">
+                    <AddressForm namespace="billing" requiredFields={{}} disabled={true} countryAfterZipForUSCA />
+                  </section>
+                )}
 
                 {/* Shipping Details Section */}
                 <div className={css.billingDetails}>


### PR DESCRIPTION
## What
Wire the new `AddressForm` into `StripePaymentForm` **behind a build-time flag** so we can preview the UI without changing checkout behavior.
- Adds import for `AddressForm`.
- Introduces `const CHECKOUT_ADDR_ENABLED = process.env.REACT_APP_CHECKOUT_ADDR_ENABLED === 'true';`
- Conditionally renders:
  <AddressForm namespace="billing" requiredFields={{}} disabled={true} countryAfterZipForUSCA />
- **No changes** to submit handlers, payload construction, or Stripe integration.

## Why
Enable safe, incremental validation of the address UI. With the flag off, production behavior is unchanged; with it on (in test/staging), the form renders for visual QA only.

## Scope
- **Modified:** `src/containers/CheckoutPage/StripePaymentForm/StripePaymentForm.js`
- **No backend or package changes.** AddressForm files were added previously (unwired).

## Behavior
- `REACT_APP_CHECKOUT_ADDR_ENABLED=false` (default): Checkout remains unchanged.
- `REACT_APP_CHECKOUT_ADDR_ENABLED=true` (test/staging): AddressForm renders (disabled/read-only). No impact on submission or network payload.

## Env / Config
- Build-time env var:
  - `REACT_APP_CHECKOUT_ADDR_ENABLED=false` (prod)
  - Optionally set to `true` on test/staging to preview the UI.
- `react-final-form` / `final-form` already present; no new deps.

## Acceptance
- With flag **false**: No visual or behavioral change; no console errors.
- With flag **true**: AddressForm renders; no console errors; submit flow/payload **unchanged**.

## Rollback
- Revert this PR; no data migrations or config changes required.

## Risk
- Low. Single-file change, fully feature-flagged, client-side only.
