### PR TITLE
chore(api): lazy-require QR/Shippo handlers under flags

### DIFF
--- a/server/apiRouter.js
+++ b/server/apiRouter.js
@@ -15,8 +15,6 @@ const loginAs = require('./api/login-as');
 const transactionLineItems = require('./api/transaction-line-items');
 const initiatePrivileged = require('./api/initiate-privileged');
 const transitionPrivileged = require('./api/transition-privileged');
-const shippoWebhook = require('./webhooks/shippoTracking');
-const qrRouter = require('./api/qr');
 const twilioSmsStatus = require('./api/twilio/sms-status');
 
 const createUserWithIdp = require('./api/auth/createUserWithIdp');
@@ -75,6 +73,7 @@ router.post('/transition-privileged', transitionPrivileged);
 
 // Shippo webhook endpoint
 if (SHIPPO_ENABLED) {
+  const shippoWebhook = require('./webhooks/shippoTracking');
   router.use('/webhooks', shippoWebhook);
 } else {
   router.use('/webhooks', (_req, res) => res.status(404).send('disabled'));
@@ -89,6 +88,7 @@ if (SMS_ENABLED) {
 
 // QR code redirect endpoint
 if (QR_ENABLED) {
+  const qrRouter = require('./api/qr');
   const qrRouterInstance = qrRouter({ getTrustedSdk }); // factory export
   router.use('/qr', qrRouterInstance);
 } else {


### PR DESCRIPTION
Move QR and Shippo handler require() calls inside their flag blocks.

Prevents loading when QR_ENABLED/SHIPPO_ENABLED are false.

No behavior change; endpoints still return 404 "disabled" when flags are off.

Scope: server/apiRouter.js only.