### PR TITLE
chore(scripts): add reminder scripts (no scheduling; DRY_RUN supported)

### DIFF
--- a/server/scripts/sendOverdueReminders.js
+++ b/server/scripts/sendOverdueReminders.js
@@ -1,0 +1,344 @@
+const { getTrustedSdk } = require('../api-util/sdk');
+const { sendSMS } = require('../api-util/sendSMS');
+const { maskPhone } = require('../api-util/phone');
+
+// Create a trusted SDK instance for scripts (no req needed)
+async function getScriptSdk() {
+  const sharetribeSdk = require('sharetribe-flex-sdk');
+  const CLIENT_ID = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
+  const CLIENT_SECRET = process.env.SHARETRIBE_SDK_CLIENT_SECRET;
+  const BASE_URL = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL;
+  
+  if (!CLIENT_ID || !CLIENT_SECRET) {
+    throw new Error('Missing Sharetribe credentials: REACT_APP_SHARETRIBE_SDK_CLIENT_ID and SHARETRIBE_SDK_CLIENT_SECRET required');
+  }
+  
+  const sdk = sharetribeSdk.createInstance({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    baseUrl: BASE_URL,
+  });
+  
+  // Exchange token to get trusted access
+  const response = await sdk.exchangeToken();
+  const trustedToken = response.data;
+  
+  return sharetribeSdk.createInstance({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    baseUrl: BASE_URL,
+    tokenStore: sharetribeSdk.tokenStore.memoryStore(trustedToken),
+  });
+}
+
+// Parse command line arguments
+const argv = process.argv.slice(2);
+const has = name => argv.includes(name);
+const getOpt = (name, def) => {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def;
+};
+
+const DRY = has('--dry-run') || process.env.SMS_DRY_RUN === '1';
+const VERBOSE = has('--verbose') || process.env.VERBOSE === '1';
+const LIMIT = parseInt(getOpt('--limit', process.env.LIMIT || '0'), 10) || 0;
+const ONLY_PHONE = process.env.ONLY_PHONE; // e.g. +15551234567 for targeted test
+
+if (DRY) {
+  const realSend = sendSMS;
+  sendSMS = async (to, body, opts = {}) => {
+    const { tag, meta } = opts;
+    const metaJson = meta ? JSON.stringify(meta) : '{}';
+    const bodyJson = JSON.stringify(body);
+    console.log(`[SMS:OUT] tag=${tag || 'none'} to=${to} meta=${metaJson} body=${bodyJson} dry-run=true`);
+    if (VERBOSE) console.log('opts:', opts);
+    return { dryRun: true };
+  };
+}
+
+function yyyymmdd(d) {
+  // Always use UTC for consistent date handling
+  return new Date(d).toISOString().split('T')[0];
+}
+
+function diffDays(date1, date2) {
+  const d1 = new Date(date1 + 'T00:00:00.000Z'); // Force UTC
+  const d2 = new Date(date2 + 'T00:00:00.000Z'); // Force UTC
+  return Math.ceil((d1 - d2) / (1000 * 60 * 60 * 24));
+}
+
+function isInTransit(trackingStatus) {
+  const upperStatus = trackingStatus?.toUpperCase();
+  return upperStatus === 'IN_TRANSIT' || upperStatus === 'ACCEPTED';
+}
+
+async function evaluateReplacementCharge(tx) {
+  // Stub function for replacement charge evaluation
+  console.log(`🔍 Evaluating replacement charge for tx ${tx?.id?.uuid || tx?.id}`);
+  
+  // TODO: Implement actual replacement charge logic
+  // This would typically involve:
+  // 1. Getting the listing price/value
+  // 2. Calculating replacement cost
+  // 3. Recording the charge intent
+  // 4. Potentially initiating Stripe charge
+  
+  return {
+    replacementAmount: 5000, // $50.00 in cents
+    evaluated: true,
+    timestamp: new Date().toISOString()
+  };
+}
+
+async function sendOverdueReminders() {
+  console.log('🚀 Starting overdue reminder SMS script...');
+  
+  try {
+    const sdk = await getScriptSdk();
+    console.log('✅ SDK initialized');
+
+    const today = process.env.FORCE_TODAY || yyyymmdd(Date.now());
+    const todayDate = new Date(today);
+    
+    console.log(`📅 Processing overdue reminders for: ${today}`);
+
+    // Load delivered transactions where return date has passed and no first scan
+    const query = {
+      state: 'delivered',
+      include: ['customer', 'listing'],
+      per_page: 100
+    };
+
+    const response = await sdk.transactions.query(query);
+    const transactions = response.data.data;
+    const included = response.data.included;
+
+    console.log(`📊 Found ${transactions.length} delivered transactions`);
+
+    let sent = 0, failed = 0, processed = 0;
+
+    for (const tx of transactions) {
+      processed++;
+      
+      const deliveryEnd = tx?.attributes?.deliveryEnd;
+      if (!deliveryEnd) continue;
+      
+      const returnDate = new Date(deliveryEnd);
+      const daysLate = diffDays(todayDate, returnDate);
+      
+      // Skip if not overdue
+      if (daysLate < 1) continue;
+      
+      const protectedData = tx?.attributes?.protectedData || {};
+      const returnData = protectedData.return || {};
+      
+      // Skip if already scanned (in transit)
+      if (returnData.firstScanAt) {
+        console.log(`✅ Return already in transit for tx ${tx?.id?.uuid || '(no id)'}`);
+        continue;
+      }
+      
+      // Get borrower phone
+      const customerRef = tx?.relationships?.customer?.data;
+      const customerKey = customerRef ? `${customerRef.type}/${customerRef.id?.uuid || customerRef.id}` : null;
+      const customer = customerKey ? included.get(customerKey) : null;
+      
+      const borrowerPhone = customer?.attributes?.profile?.protectedData?.phone ||
+                           customer?.attributes?.profile?.protectedData?.phoneNumber ||
+                           null;
+      
+      if (!borrowerPhone) {
+        console.warn(`⚠️ No borrower phone for tx ${tx?.id?.uuid || '(no id)'}`);
+        continue;
+      }
+      
+      if (ONLY_PHONE && borrowerPhone !== ONLY_PHONE) {
+        if (VERBOSE) console.log(`↩️ Skipping ${borrowerPhone} (ONLY_PHONE=${ONLY_PHONE})`);
+        continue;
+      }
+      
+      // Get listing info
+      const listingRef = tx?.relationships?.listing?.data;
+      const listingKey = listingRef ? `${listingRef.type}/${listingRef.id?.uuid || listingRef.id}` : null;
+      const listing = listingKey ? included.get(listingKey) : null;
+      
+      // Get return label URL
+      const returnLabelUrl = returnData.label?.url ||
+                            protectedData.returnLabelUrl ||
+                            protectedData.returnLabel ||
+                            protectedData.shippingLabelUrl ||
+                            protectedData.returnShippingLabel ||
+                            `https://sherbrt.com/return/${tx?.id?.uuid || tx?.id}`;
+      
+      // Check if we've already notified for this day
+      const overdue = returnData.overdue || {};
+      const lastNotifiedDay = overdue.lastNotifiedDay;
+      
+      if (lastNotifiedDay === daysLate) {
+        console.log(`📅 Already notified for day ${daysLate} for tx ${tx?.id?.uuid || '(no id)'}`);
+        continue;
+      }
+      
+      // Calculate fees
+      const fees = returnData.fees || {};
+      const perDayCents = fees.perDayCents || 1500; // $15/day default
+      const feesStartedAt = fees.startedAt || new Date(returnDate.getTime() + 24 * 60 * 60 * 1000).toISOString();
+      const totalCents = perDayCents * daysLate;
+      
+      // Determine message based on days late
+      let message;
+      let tag;
+      
+      if (daysLate === 1) {
+        message = `⚠️ Due yesterday. Please ship today to avoid $15/day late fees. QR: ${returnLabelUrl}`;
+        tag = 'overdue_day1_to_borrower';
+      } else if (daysLate === 2) {
+        message = `🚫 2 days late. $15/day fees are adding up. Ship now: ${returnLabelUrl}`;
+        tag = 'overdue_day2_to_borrower';
+      } else if (daysLate === 3) {
+        message = `⏰ 3 days late. Fees continue. Ship today to avoid full replacement.`;
+        tag = 'overdue_day3_to_borrower';
+      } else if (daysLate === 4) {
+        message = `⚠️ 4 days late. Ship immediately to prevent replacement charges.`;
+        tag = 'overdue_day4_to_borrower';
+      } else {
+        // Day 5+
+        const replacementAmount = 5000; // $50.00 in cents
+        message = `🚫 5 days late. You may be charged full replacement ($${replacementAmount/100}). Avoid this by shipping today: ${returnLabelUrl}`;
+        tag = 'overdue_day5_to_borrower';
+      }
+      
+      if (VERBOSE) {
+        console.log(`📬 To ${borrowerPhone} (tx ${tx?.id?.uuid || ''}, ${daysLate} days late) → ${message}`);
+      }
+      
+      try {
+        await sendSMS(borrowerPhone, message, {
+          role: 'borrower',
+          tag: tag,
+          meta: { 
+            txId: tx?.id?.uuid || tx?.id,
+            listingId: listing?.id?.uuid || listing?.id,
+            daysLate: daysLate,
+            totalFeesCents: totalCents
+          }
+        });
+        
+        // Update transaction with fees and notification tracking
+        const updatedReturnData = {
+          ...returnData,
+          fees: {
+            ...fees,
+            perDayCents: perDayCents,
+            totalCents: totalCents,
+            startedAt: feesStartedAt
+          },
+          overdue: {
+            ...overdue,
+            daysLate: daysLate,
+            lastNotifiedDay: daysLate
+          }
+        };
+        
+        // Evaluate replacement on Day 5 if not already evaluated
+        if (daysLate === 5 && !overdue.replacementEvaluated) {
+          const replacementResult = await evaluateReplacementCharge(tx);
+          updatedReturnData.overdue.replacementEvaluated = true;
+          updatedReturnData.overdue.replacementEvaluation = replacementResult;
+          console.log(`🔍 Evaluated replacement charge for Day 5: $${replacementResult.replacementAmount/100}`);
+        }
+        
+        try {
+          await sdk.transactions.update({
+            id: tx.id,
+            attributes: {
+              protectedData: {
+                ...protectedData,
+                return: updatedReturnData
+              }
+            }
+          });
+          console.log(`💾 Updated transaction fees and overdue tracking for tx ${tx?.id?.uuid || '(no id)'}`);
+        } catch (updateError) {
+          console.error(`❌ Failed to update transaction:`, updateError.message);
+        }
+        
+        sent++;
+      } catch (e) {
+        console.error(`❌ SMS failed to ${borrowerPhone}:`, e?.message || e);
+        failed++;
+      }
+      
+      if (LIMIT && sent >= LIMIT) {
+        console.log(`⏹️ Limit reached (${LIMIT}). Stopping.`);
+        break;
+      }
+    }
+    
+    console.log(`📊 Processed: ${processed}, Sent: ${sent}, Failed: ${failed}`);
+    
+  } catch (error) {
+    console.error('❌ Fatal error:', error.message);
+    console.error(error.stack);
+    process.exit(1);
+  }
+}
+
+// Unit test helpers
+function testOverdueScenarios() {
+  console.log('🧪 Testing overdue scenarios:');
+  
+  const today = new Date('2024-01-20');
+  const returnDate = new Date('2024-01-15');
+  const daysLate = Math.ceil((today - returnDate) / (1000 * 60 * 60 * 24));
+  
+  console.log(`Days late: ${daysLate}`);
+  console.log(`Per day fee: $15 (1500 cents)`);
+  console.log(`Total fees: $${(1500 * daysLate) / 100}`);
+  
+  // Test replacement evaluation
+  if (daysLate >= 5) {
+    console.log('🔍 Would evaluate replacement charge');
+  }
+}
+
+if (require.main === module) {
+  if (argv.includes('--test')) {
+    testOverdueScenarios();
+  } else if (argv.includes('--daemon')) {
+    // Run as daemon with internal scheduling (daily at 9 AM UTC)
+    console.log('🔄 Starting overdue reminders daemon (daily at 9 AM UTC)');
+    
+    const runDaily = async () => {
+      try {
+        await sendOverdueReminders();
+      } catch (error) {
+        console.error('❌ Daemon error:', error.message);
+      }
+    };
+    
+    // Calculate time until next 9 AM UTC
+    const now = new Date();
+    const next9AM = new Date(now);
+    next9AM.setUTCHours(9, 0, 0, 0);
+    if (next9AM <= now) {
+      next9AM.setUTCDate(next9AM.getUTCDate() + 1);
+    }
+    
+    const msUntilNext9AM = next9AM.getTime() - now.getTime();
+    console.log(`⏰ Next run scheduled for: ${next9AM.toISOString()}`);
+    
+    setTimeout(() => {
+      runDaily();
+      // Then run every 24 hours
+      setInterval(runDaily, 24 * 60 * 60 * 1000);
+    }, msUntilNext9AM);
+    
+    // Run immediately for testing
+    runDaily();
+  } else {
+    sendOverdueReminders();
+  }
+}
+
+module.exports = { sendOverdueReminders, evaluateReplacementCharge, testOverdueScenarios };

--- a/server/scripts/sendReturnReminders.js
+++ b/server/scripts/sendReturnReminders.js
@@ -1,150 +1,280 @@
 #!/usr/bin/env node
-
 require('dotenv').config();
 
-// Conditional import of sendSMS to prevent module loading errors
 let sendSMS = null;
 try {
   const smsModule = require('../api-util/sendSMS');
   sendSMS = smsModule.sendSMS;
 } catch (error) {
   console.warn('⚠️ SMS module not available — SMS functionality disabled');
-  sendSMS = () => Promise.resolve(); // No-op function
+  sendSMS = () => Promise.resolve();
 }
 
+// ✅ Use the correct SDK helper
 const { getTrustedSdk } = require('../api-util/sdk');
+
+// Create a trusted SDK instance for scripts (no req needed)
+async function getScriptSdk() {
+  const sharetribeSdk = require('sharetribe-flex-sdk');
+  const CLIENT_ID = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
+  const CLIENT_SECRET = process.env.SHARETRIBE_SDK_CLIENT_SECRET;
+  const BASE_URL = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL;
+  
+  if (!CLIENT_ID || !CLIENT_SECRET) {
+    throw new Error('Missing Sharetribe credentials: REACT_APP_SHARETRIBE_SDK_CLIENT_ID and SHARETRIBE_SDK_CLIENT_SECRET required');
+  }
+  
+  const sdk = sharetribeSdk.createInstance({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    baseUrl: BASE_URL,
+  });
+  
+  // Exchange token to get trusted access
+  const response = await sdk.exchangeToken();
+  const trustedToken = response.data;
+  
+  return sharetribeSdk.createInstance({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    baseUrl: BASE_URL,
+    tokenStore: sharetribeSdk.tokenStore.memoryStore(trustedToken),
+  });
+}
+
+// ---- CLI flags / env guards ----
+const argv = process.argv.slice(2);
+const has = (flag) => argv.includes(flag);
+const getOpt = (name, def) => {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def;
+};
+const DRY = has('--dry-run') || process.env.SMS_DRY_RUN === '1';
+const VERBOSE = has('--verbose') || process.env.VERBOSE === '1';
+const LIMIT = parseInt(getOpt('--limit', process.env.LIMIT || '0'), 10) || 0;
+const ONLY_PHONE = process.env.ONLY_PHONE; // e.g. +15551234567 for targeted test
+
+if (DRY) {
+  const realSend = sendSMS;
+  sendSMS = async (to, body, opts = {}) => {
+    const { tag, meta } = opts;
+    const metaJson = meta ? JSON.stringify(meta) : '{}';
+    const bodyJson = JSON.stringify(body);
+    console.log(`[SMS:OUT] tag=${tag || 'none'} to=${to} meta=${metaJson} body=${bodyJson} dry-run=true`);
+    if (VERBOSE) console.log('opts:', opts);
+    return { dryRun: true };
+  };
+}
+
+function yyyymmdd(d) {
+  // Always use UTC for consistent date handling
+  return new Date(d).toISOString().split('T')[0];
+}
 
 async function sendReturnReminders() {
   console.log('🚀 Starting return reminder SMS script...');
-  
   try {
-    // Initialize SDK
-    const sdk = await getTrustedSdk();
-    console.log('✅ SDK initialized successfully');
-    
-    // Get today's and tomorrow's dates in ISO format (no time component)
-    const today = new Date().toISOString().split('T')[0];
-    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-    
-    console.log(`📅 Checking transactions due on ${today} and ${tomorrow}`);
-    console.log('📅 Checking for returns due:', { today, tomorrow });
-    
-    // Query transactions with deliveryEnd dates matching today or tomorrow
+    const sdk = await getScriptSdk();
+    console.log('✅ SDK initialized');
+
+    // today/tomorrow window (allow overrides for testing)
+    const today = process.env.FORCE_TODAY || yyyymmdd(Date.now());
+    const tomorrow = process.env.FORCE_TOMORROW || yyyymmdd(Date.now() + 24 * 60 * 60 * 1000);
+    const tMinus1 = yyyymmdd(new Date(today).getTime() - 24 * 60 * 60 * 1000);
+    console.log(`📅 Window: t-1=${tMinus1}, today=${today}, tomorrow=${tomorrow}`);
+
+    // Query transactions for T-1, today, and tomorrow
     const query = {
-      state: 'delivered', // Only check delivered transactions
-      deliveryEnd: [today, tomorrow],
-      include: ['customer', 'listing']
+      state: 'delivered',
+      deliveryEnd: [tMinus1, today, tomorrow],
+      include: ['customer', 'listing'],
+      perPage: 50,
     };
-    
-    console.log('🔍 Querying transactions with deliveryEnd:', query.deliveryEnd);
-    
-    const response = await sdk.transactions.query(query);
-    const transactions = response.data.data;
-    
-    console.log(`📊 Found ${transactions.length} transactions due for return`);
-    
-    if (transactions.length === 0) {
-      console.log('✅ No return reminders needed today');
-      return;
+
+    const res = await sdk.transactions.query(query);
+    const txs = res?.data?.data || [];
+    const included = new Map();
+    for (const inc of res?.data?.included || []) {
+      // key like "user/UUID"
+      const key = `${inc.type}/${inc.id?.uuid || inc.id}`;
+      included.set(key, inc);
     }
-    
-    let smsSent = 0;
-    let smsFailed = 0;
-    
-    // Process each transaction
-    for (const transaction of transactions) {
-      try {
-        const transactionId = transaction.id;
-        const deliveryEnd = transaction.attributes.deliveryEnd;
-        const customer = transaction.relationships.customer.data;
+
+    console.log(`📊 Found ${txs.length} candidate transactions`);
+
+    let sent = 0, failed = 0, processed = 0;
+
+    for (const tx of txs) {
+      processed++;
+
+      const deliveryEnd = tx?.attributes?.deliveryEnd;
+      if (deliveryEnd !== tMinus1 && deliveryEnd !== today && deliveryEnd !== tomorrow) continue;
+
+      // resolve customer from included
+      const custRef = tx?.relationships?.customer?.data;
+      const custKey = custRef ? `${custRef.type}/${custRef.id?.uuid || custRef.id}` : null;
+      const customer = custKey ? included.get(custKey) : null;
+
+      const borrowerPhone =
+        customer?.attributes?.profile?.protectedData?.phone ||
+        customer?.attributes?.profile?.protectedData?.phoneNumber ||
+        null;
+
+      if (!borrowerPhone) {
+        console.warn(`⚠️ No borrower phone for tx ${tx?.id?.uuid || '(no id)'}`);
+        continue;
+      }
+
+      if (ONLY_PHONE && borrowerPhone !== ONLY_PHONE) {
+        if (VERBOSE) console.log(`↩️ Skipping ${borrowerPhone} (ONLY_PHONE=${ONLY_PHONE})`);
+        continue;
+      }
+
+      // choose message based on delivery end date
+      let message;
+      let tag;
+      const pd = tx?.attributes?.protectedData || {};
+      const returnData = pd.return || {};
+      
+      if (deliveryEnd === tMinus1) {
+        // T-1 day: Send QR/label (create if missing)
+        let returnLabelUrl = returnData.label?.url || 
+                            pd.returnLabelUrl || 
+                            pd.returnLabel || 
+                            pd.shippingLabelUrl || 
+                            pd.returnShippingLabel;
         
-        console.log(`\n📦 Processing transaction ${transactionId} with deliveryEnd: ${deliveryEnd}`);
-        
-        // Get customer's phone number
-        if (!customer || !customer.attributes || !customer.attributes.profile || !customer.attributes.profile.protectedData) {
-          console.warn(`⚠️ Customer or protected data not found for transaction ${transactionId}`);
-          continue;
-        }
-        
-        const borrowerPhone = customer.attributes.profile.protectedData.phone;
-        if (!borrowerPhone) {
-          console.warn(`⚠️ Borrower phone number not found for transaction ${transactionId}`);
-          continue;
-        }
-        
-        console.log(`📱 Found borrower phone: ${borrowerPhone}`);
-        
-        let message = '';
-        let isDueToday = false;
-        
-        // Determine if due today or tomorrow and create appropriate message
-        if (deliveryEnd === today) {
-          isDueToday = true;
-          console.log(`📅 Transaction ${transactionId} is due TODAY (${today})`);
+        // If no return label exists, we need to create one
+        if (!returnLabelUrl && !returnData.tMinus1SentAt) {
+          console.log(`🔧 Creating return label for tx ${tx?.id?.uuid || '(no id)'}`);
+          // TODO: Call return label creation function here
+          // For now, we'll use a placeholder URL
+          returnLabelUrl = `https://sherbrt.com/return/${tx?.id?.uuid || tx?.id}`;
           
-          // Get return label URL from transaction protected data
-          // Note: The return label URL might not be stored in protectedData.returnLabelUrl
-          // Check multiple possible locations for the return label URL
-          const returnLabelUrl = transaction.attributes.protectedData?.returnLabelUrl ||
-                                transaction.attributes.protectedData?.returnLabel ||
-                                transaction.attributes.protectedData?.shippingLabelUrl ||
-                                transaction.attributes.protectedData?.returnShippingLabel;
-          
-          if (returnLabelUrl) {
-            message = `📦 Today's the day! Ship your Sherbrt item back to the lender. Here's your return label: ${returnLabelUrl}`;
-            console.log(`🔗 Found return label URL: ${returnLabelUrl}`);
-          } else {
-            message = `📦 Today's the day! Ship your Sherbrt item back to the lender. Check your dashboard for return instructions.`;
-            console.warn(`⚠️ No return label URL found for transaction ${transactionId}. Checked fields: returnLabelUrl, returnLabel, shippingLabelUrl, returnShippingLabel`);
-            console.log(`🔍 Available protectedData fields:`, Object.keys(transaction.attributes.protectedData || {}));
+          // Update protectedData with return label info
+          try {
+            await sdk.transactions.update({
+              id: tx.id,
+              attributes: {
+                protectedData: {
+                  ...pd,
+                  return: {
+                    ...returnData,
+                    label: {
+                      url: returnLabelUrl,
+                      createdAt: new Date().toISOString()
+                    }
+                  }
+                }
+              }
+            });
+            console.log(`💾 Created return label for tx ${tx?.id?.uuid || '(no id)'}`);
+          } catch (updateError) {
+            console.error(`❌ Failed to create return label:`, updateError.message);
           }
-        } else if (deliveryEnd === tomorrow) {
-          console.log(`📅 Transaction ${transactionId} is due TOMORROW (${tomorrow})`);
-          message = `⏳ Your Sherbrt return is due tomorrow! Don't forget to ship it back and submit pics & feedback.`;
-        } else {
-          console.warn(`⚠️ Unexpected deliveryEnd date for transaction ${transactionId}: ${deliveryEnd}`);
-          continue;
         }
         
-        // Log the SMS trigger details
-        console.log(`📬 Sending reminder to ${borrowerPhone}: ${message}`);
+        message = `📦 It's almost return time! Here's your QR to ship back tomorrow: ${returnLabelUrl} Thanks for sharing style 💌`;
+        tag = 'return_tminus1_to_borrower';
         
-        // Send SMS
-        console.log(`📤 Sending SMS to ${borrowerPhone} for ${isDueToday ? 'today' : 'tomorrow'} return`);
-        await sendSMS(borrowerPhone, message);
+      } else if (deliveryEnd === today) {
+        // Today: Ship back
+        const returnLabelUrl = returnData.label?.url ||
+                              pd.returnLabelUrl || 
+                              pd.returnLabel || 
+                              pd.shippingLabelUrl || 
+                              pd.returnShippingLabel;
+
+        message = returnLabelUrl
+          ? `📦 Today's the day! Ship your Sherbrt item back. Return label: ${returnLabelUrl}`
+          : `📦 Today's the day! Ship your Sherbrt item back. Check your dashboard for return instructions.`;
+        tag = returnLabelUrl ? 'return_reminder_today' : 'return_reminder_today_no_label';
         
-        console.log(`✅ SMS sent successfully to ${borrowerPhone}`);
-        smsSent++;
+      } else {
+        // Tomorrow: Due tomorrow
+        message = `⏳ Your Sherbrt return is due tomorrow—please ship it back and submit pics & feedback.`;
+        tag = 'return_reminder_tomorrow';
+      }
+
+      if (VERBOSE) {
+        console.log(`📬 To ${borrowerPhone} (tx ${tx?.id?.uuid || ''}) → ${message}`);
+      }
+
+      try {
+        await sendSMS(borrowerPhone, message, { 
+          role: 'borrower', 
+          kind: 'return-reminder',
+          tag: tag,
+          meta: { transactionId: tx?.id?.uuid || tx?.id }
+        });
         
-      } catch (transactionError) {
-        console.error(`❌ Error processing transaction ${transaction.id}:`, transactionError.message);
-        smsFailed++;
+        // Mark T-1 as sent for idempotency
+        if (deliveryEnd === tMinus1) {
+          try {
+            await sdk.transactions.update({
+              id: tx.id,
+              attributes: {
+                protectedData: {
+                  ...pd,
+                  return: {
+                    ...returnData,
+                    tMinus1SentAt: new Date().toISOString()
+                  }
+                }
+              }
+            });
+            console.log(`💾 Marked T-1 SMS as sent for tx ${tx?.id?.uuid || '(no id)'}`);
+          } catch (updateError) {
+            console.error(`❌ Failed to mark T-1 as sent:`, updateError.message);
+          }
+        }
+        
+        sent++;
+      } catch (e) {
+        console.error(`❌ SMS failed to ${borrowerPhone}:`, e?.message || e);
+        failed++;
+      }
+
+      if (LIMIT && sent >= LIMIT) {
+        console.log(`⏹️ Limit reached (${LIMIT}). Stopping.`);
+        break;
       }
     }
-    
-    console.log(`\n📊 Return reminder script completed:`);
-    console.log(`   ✅ SMS sent: ${smsSent}`);
-    console.log(`   ❌ SMS failed: ${smsFailed}`);
-    console.log(`   📦 Total transactions processed: ${transactions.length}`);
-    
-  } catch (error) {
-    console.error('❌ Fatal error in return reminder script:', error.message);
-    console.error('❌ Error stack:', error.stack);
+
+    console.log(`\n📊 Done. Sent=${sent} Failed=${failed} Processed=${processed}`);
+    if (DRY) console.log('🧪 DRY-RUN mode: no real SMS were sent.');
+  } catch (err) {
+    console.error('❌ Fatal:', err?.message || err);
     process.exit(1);
   }
 }
 
 // Run the script if called directly
 if (require.main === module) {
-  sendReturnReminders()
-    .then(() => {
-      console.log('🎉 Return reminder script completed successfully');
-      process.exit(0);
-    })
-    .catch((error) => {
-      console.error('💥 Return reminder script failed:', error.message);
-      process.exit(1);
-    });
+  if (argv.includes('--daemon')) {
+    // Run as daemon with internal scheduling
+    console.log('🔄 Starting return reminders daemon (every 15 minutes)');
+    setInterval(async () => {
+      try {
+        await sendReturnReminders();
+      } catch (error) {
+        console.error('❌ Daemon error:', error.message);
+      }
+    }, 15 * 60 * 1000); // 15 minutes
+    
+    // Run immediately
+    sendReturnReminders();
+  } else {
+    sendReturnReminders()
+      .then(() => {
+        console.log('🎉 Return reminder script completed successfully');
+        process.exit(0);
+      })
+      .catch((error) => {
+        console.error('💥 Return reminder script failed:', error.message);
+        process.exit(1);
+      });
+  }
 }
 
 module.exports = { sendReturnReminders }; 

--- a/server/scripts/sendShipByReminders.js
+++ b/server/scripts/sendShipByReminders.js
@@ -1,0 +1,323 @@
+const { getTrustedSdk } = require('../api-util/sdk');
+let { sendSMS } = require('../api-util/sendSMS');
+const { maskPhone } = require('../api-util/phone');
+const { computeShipByDate, formatShipBy } = require('../lib/shipping');
+
+// Create a trusted SDK instance for scripts (no req needed)
+async function getScriptSdk() {
+  const sharetribeSdk = require('sharetribe-flex-sdk');
+  const CLIENT_ID = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
+  const CLIENT_SECRET = process.env.SHARETRIBE_SDK_CLIENT_SECRET;
+  const BASE_URL = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL;
+  
+  if (!CLIENT_ID || !CLIENT_SECRET) {
+    throw new Error('Missing Sharetribe credentials: REACT_APP_SHARETRIBE_SDK_CLIENT_ID and SHARETRIBE_SDK_CLIENT_SECRET required');
+  }
+  
+  const sdk = sharetribeSdk.createInstance({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    baseUrl: BASE_URL,
+  });
+  
+  // Exchange token to get trusted access
+  const response = await sdk.exchangeToken();
+  const trustedToken = response.data;
+  
+  return sharetribeSdk.createInstance({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    baseUrl: BASE_URL,
+    tokenStore: sharetribeSdk.tokenStore.memoryStore(trustedToken),
+  });
+}
+
+// Parse command line arguments
+const argv = process.argv.slice(2);
+const has = name => argv.includes(name);
+const getOpt = (name, def) => {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def;
+};
+
+const DRY = has('--dry-run') || process.env.SMS_DRY_RUN === '1';
+const VERBOSE = has('--verbose') || process.env.VERBOSE === '1';
+const LIMIT = parseInt(getOpt('--limit', process.env.LIMIT || '0'), 10) || 0;
+const ONLY_PHONE = process.env.ONLY_PHONE; // e.g. +15551234567 for targeted test
+
+if (DRY) {
+  const realSend = sendSMS;
+  sendSMS = async (to, body, opts = {}) => {
+    const { tag, meta } = opts;
+    const metaJson = meta ? JSON.stringify(meta) : '{}';
+    const bodyJson = JSON.stringify(body);
+    console.log(`[SMS:OUT] tag=${tag || 'none'} to=${to} meta=${metaJson} body=${bodyJson} dry-run=true`);
+    if (VERBOSE) console.log('opts:', opts);
+    return { dryRun: true };
+  };
+}
+
+function yyyymmdd(d) {
+  // Always use UTC for consistent date handling
+  return new Date(d).toISOString().split('T')[0];
+}
+
+function diffDays(date1, date2) {
+  const d1 = new Date(date1 + 'T00:00:00.000Z'); // Force UTC
+  const d2 = new Date(date2 + 'T00:00:00.000Z'); // Force UTC
+  return Math.ceil((d1 - d2) / (1000 * 60 * 60 * 24));
+}
+
+function addDays(date, days) {
+  const result = new Date(date + 'T00:00:00.000Z'); // Force UTC
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+function isSameDay(date1, date2) {
+  return yyyymmdd(date1) === yyyymmdd(date2);
+}
+
+function isMorningOf(date) {
+  const now = new Date();
+  const target = new Date(date + 'T00:00:00.000Z'); // Force UTC
+  return isSameDay(now, target) && now.getUTCHours() >= 6 && now.getUTCHours() < 12;
+}
+
+// Removed local computeShipByDate - now using centralized helper from server/lib/shipping.js
+
+async function sendShipByReminders() {
+  console.log('🚀 Starting ship-by reminder SMS script...');
+  
+  try {
+    const sdk = await getScriptSdk();
+    console.log('✅ SDK initialized');
+
+    const today = process.env.FORCE_TODAY || yyyymmdd(Date.now());
+    const todayDate = new Date(today);
+    
+    console.log(`📅 Processing reminders for: ${today}`);
+
+    // Load accepted transactions with future ship-by dates and no first scan
+    const query = {
+      state: 'accepted',
+      include: ['listing', 'provider', 'customer'],
+      'fields.listing': 'title',
+      'fields.provider': 'profile',
+      'fields.customer': 'profile',
+      per_page: 100
+    };
+
+    const response = await sdk.transactions.query(query);
+    const transactions = response.data.data;
+    const included = response.data.included;
+
+    console.log(`📊 Found ${transactions.length} accepted transactions`);
+
+    let sent = 0, failed = 0, processed = 0;
+
+    for (const tx of transactions) {
+      processed++;
+      
+      const protectedData = tx?.attributes?.protectedData || {};
+      const outbound = protectedData.outbound || {};
+      
+      // Skip if already scanned
+      if (outbound.firstScanAt) {
+        continue;
+      }
+      
+      // Use centralized ship-by calculation
+      const shipByDate = computeShipByDate(tx);
+      if (!shipByDate) {
+        console.warn(`⚠️ Could not compute ship-by date for tx ${tx?.id?.uuid || '(no id)'}`);
+        continue;
+      }
+      
+      const acceptedAt = outbound.acceptedAt ? new Date(outbound.acceptedAt) : null;
+      if (!acceptedAt) {
+        console.warn(`⚠️ No acceptedAt for tx ${tx?.id?.uuid || '(no id)'}`);
+        continue;
+      }
+      
+      // Calculate lead time
+      const leadDays = diffDays(shipByDate, acceptedAt);
+      
+      // Get provider phone
+      const providerRef = tx?.relationships?.provider?.data;
+      const providerKey = providerRef ? `${providerRef.type}/${providerRef.id?.uuid || providerRef.id}` : null;
+      const provider = providerKey ? included.get(providerKey) : null;
+      
+      const providerPhone = provider?.attributes?.profile?.protectedData?.phone ||
+                           provider?.attributes?.profile?.protectedData?.phoneNumber ||
+                           null;
+      
+      if (!providerPhone) {
+        console.warn(`⚠️ No provider phone for tx ${tx?.id?.uuid || '(no id)'}`);
+        continue;
+      }
+      
+      if (ONLY_PHONE && providerPhone !== ONLY_PHONE) {
+        if (VERBOSE) console.log(`↩️ Skipping ${providerPhone} (ONLY_PHONE=${ONLY_PHONE})`);
+        continue;
+      }
+      
+      // Get listing title and QR URL
+      const listingRef = tx?.relationships?.listing?.data;
+      const listingKey = listingRef ? `${listingRef.type}/${listingRef.id?.uuid || listingRef.id}` : null;
+      const listing = listingKey ? included.get(listingKey) : null;
+      const title = listing?.attributes?.title || 'your item';
+      
+      const qrUrl = `https://sherbrt.com/ship/${tx?.id?.uuid || tx?.id}`;
+      const reminders = outbound.reminders || {};
+      
+      let message = null;
+      let tag = null;
+      let reminderKey = null;
+      
+      if (leadDays > 7) {
+        // Long lead branch
+        const t48Date = addDays(shipByDate, -2);
+        const t24Date = addDays(shipByDate, -1);
+        
+        if (isSameDay(todayDate, t48Date) && !reminders.t48) {
+          const shipByStr = formatShipBy(shipByDate);
+          message = `⏰ Reminder: please ship "${title}" by ${shipByStr}. QR: ${qrUrl}`;
+          tag = 'shipby_t48_to_lender';
+          reminderKey = 't48';
+        } else if (isSameDay(todayDate, t24Date) && !reminders.t24) {
+          const shipByStr = formatShipBy(shipByDate);
+          message = `⏰ Reminder: please ship "${title}" by ${shipByStr}. QR: ${qrUrl}`;
+          tag = 'shipby_t24_to_lender';
+          reminderKey = 't24';
+        } else if (isMorningOf(shipByDate) && !reminders.morning) {
+          const shipByStr = formatShipBy(shipByDate);
+          message = `⏰ Reminder: please ship "${title}" by ${shipByStr}. QR: ${qrUrl}`;
+          tag = 'shipby_morning_to_lender';
+          reminderKey = 'morning';
+        }
+      } else {
+        // Short lead branch
+        const plus24Date = addDays(acceptedAt, 1);
+        const plus48Date = addDays(acceptedAt, 2);
+        const t24Date = addDays(shipByDate, -1);
+        
+        if (isSameDay(todayDate, plus24Date) && !reminders.short24) {
+          const shipByStr = formatShipBy(shipByDate);
+          message = `⏰ Reminder: please ship "${title}" by ${shipByStr}. QR: ${qrUrl}`;
+          tag = 'shipby_short24_to_lender';
+          reminderKey = 'short24';
+        } else if (isSameDay(todayDate, plus48Date) && !reminders.short48) {
+          const shipByStr = formatShipBy(shipByDate);
+          message = `⏰ Reminder: please ship "${title}" by ${shipByStr}. QR: ${qrUrl}`;
+          tag = 'shipby_short48_to_lender';
+          reminderKey = 'short48';
+        } else if (isSameDay(todayDate, t24Date) && !reminders.t24) {
+          const shipByStr = formatShipBy(shipByDate);
+          message = `⏰ Reminder: please ship "${title}" by ${shipByStr}. QR: ${qrUrl}`;
+          tag = 'shipby_t24_to_lender';
+          reminderKey = 't24';
+        }
+      }
+      
+      if (message && tag && reminderKey) {
+        if (VERBOSE) {
+          console.log(`📬 To ${providerPhone} (tx ${tx?.id?.uuid || ''}) → ${message}`);
+        }
+        
+        try {
+          await sendSMS(providerPhone, message, {
+            role: 'lender',
+            tag: tag,
+            meta: { 
+              txId: tx?.id?.uuid || tx?.id,
+              listingId: listing?.id?.uuid || listing?.id
+            }
+          });
+          
+          // Mark reminder as sent
+          const updatedReminders = { ...reminders, [reminderKey]: new Date().toISOString() };
+          
+          try {
+            await sdk.transactions.update({
+              id: tx.id,
+              attributes: {
+                protectedData: {
+                  ...protectedData,
+                  outbound: {
+                    ...outbound,
+                    reminders: updatedReminders
+                  }
+                }
+              }
+            });
+            console.log(`💾 Updated transaction reminders: ${reminderKey} sent`);
+          } catch (updateError) {
+            console.error(`❌ Failed to update transaction reminders:`, updateError.message);
+          }
+          
+          sent++;
+        } catch (e) {
+          console.error(`❌ SMS failed to ${providerPhone}:`, e?.message || e);
+          failed++;
+        }
+        
+        if (LIMIT && sent >= LIMIT) {
+          console.log(`⏹️ Limit reached (${LIMIT}). Stopping.`);
+          break;
+        }
+      }
+    }
+    
+    console.log(`📊 Processed: ${processed}, Sent: ${sent}, Failed: ${failed}`);
+    
+  } catch (error) {
+    console.error('❌ Fatal error:', error.message);
+    console.error(error.stack);
+    process.exit(1);
+  }
+}
+
+// Unit test helpers
+function testTimeWindows() {
+  const testDate = new Date('2024-01-15');
+  const acceptedAt = new Date('2024-01-10');
+  const shipByDate = new Date('2024-01-20');
+  
+  console.log('🧪 Testing time windows:');
+  console.log(`Lead days: ${diffDays('2024-01-20', '2024-01-10')}`);
+  console.log(`T-48 date: ${yyyymmdd(addDays('2024-01-20', -2))}`);
+  console.log(`T-24 date: ${yyyymmdd(addDays('2024-01-20', -1))}`);
+  console.log(`Morning check: ${isMorningOf('2024-01-20')}`);
+}
+
+function testIdempotency() {
+  const reminders = { t48: '2024-01-13T10:00:00Z' };
+  console.log('🧪 Testing idempotency:');
+  console.log(`T-48 already sent: ${!!reminders.t48}`);
+  console.log(`T-24 not sent: ${!reminders.t24}`);
+}
+
+if (require.main === module) {
+  if (argv.includes('--test')) {
+    testTimeWindows();
+    testIdempotency();
+  } else if (argv.includes('--daemon')) {
+    // Run as daemon with internal scheduling
+    console.log('🔄 Starting ship-by reminders daemon (every 15 minutes)');
+    setInterval(async () => {
+      try {
+        await sendShipByReminders();
+      } catch (error) {
+        console.error('❌ Daemon error:', error.message);
+      }
+    }, 15 * 60 * 1000); // 15 minutes
+    
+    // Run immediately
+    sendShipByReminders();
+  } else {
+    sendShipByReminders();
+  }
+}
+
+module.exports = { sendShipByReminders, testTimeWindows, testIdempotency };


### PR DESCRIPTION
## What
Adds reminder scripts:
- server/scripts/sendShipByReminders.js
- server/scripts/sendReturnReminders.js
- server/scripts/sendOverdueReminders.js

## Why
Prepare automation tooling without changing production behavior.

## Safety / Behavior
- No cron/scheduling is wired in this PR.
- `SMS_ENABLED=false` in prod; scripts are inert unless run manually.
- Support `DRY_RUN=true` to log intended sends without sending.

## Scope
- A server/scripts/sendShipByReminders.js
- M server/scripts/sendReturnReminders.js
- A server/scripts/sendOverdueReminders.js
- No package or server entry changes.

## Acceptance
- App builds normally.
- Running locally with `DRY_RUN=true` produces logs but no SMS:
