### PR TITLE
fix(csp): enhance CSP nonce support and expand required hosts

### DIFF
--- a/server/csp.js
+++ b/server/csp.js
@@ -41,6 +41,7 @@ const defaultDirectives = {
     baseUrl,
     assetCdnBaseUrl,
     '*.st-api.com',
+    'https://cdn.st-api.com',
     'maps.googleapis.com',
     'places.googleapis.com',
     '*.tiles.mapbox.com',
@@ -63,10 +64,11 @@ const defaultDirectives = {
     'sentry.io',
     '*.sentry.io',
     'https://api.stripe.com',
+    'https://m.stripe.com',
     '*.stripe.com',
   ].filter(Boolean),
   fontSrc: [self, data, 'assets-sharetribecom.sharetribe.com', 'fonts.gstatic.com'],
-  formAction: [self],
+  formAction: [self, 'https://hooks.stripe.com'],
   frameSrc: [
     self,
     'https://js.stripe.com',
@@ -125,10 +127,12 @@ const defaultDirectives = {
     'js.stripe.com',
     'plausible.io',
   ],
-  "script-src-elem": [self, blob, "https://js.stripe.com", "https://api.mapbox.com", "https://*.mapbox.com"],
+  "script-src-elem": [self, (req, res) => `'nonce-${res.locals.cspNonce}'`, blob, "https://js.stripe.com", "https://api.mapbox.com", "https://*.mapbox.com"],
   "manifest-src": [self],
   "worker-src": [self, blob],
   styleSrc: [self, unsafeInline, 'fonts.googleapis.com', 'api.mapbox.com'],
+  frameAncestors: [self],
+  objectSrc: ["'none'"],
 };
 
 /**


### PR DESCRIPTION
- Add nonce support to script-src-elem directive for inline script compatibility
- Include https://cdn.st-api.com and https://m.stripe.com in connectSrc
- Add https://hooks.stripe.com to formAction for Stripe webhook redirects
- Add frameAncestors and objectSrc directives for enhanced security
- Ensure comprehensive host coverage for FTW + Stripe + Mapbox + Sharetribe Console

Resolves CSP blocking issues for:
- Inline scripts with proper nonce validation
- Sharetribe Console/CDN asset loading
- Stripe payment processing
- Mapbox integration