### PR TITLE
[infra] Wave-1: envFlags for client + npm script consistency (no dep changes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "app",
   "version": "8.0.1",
+  "proxy": "http://localhost:3500",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {
@@ -97,7 +98,7 @@
     }
   },
   "scripts": {
-    "audit": "yarn audit --json | node scripts/audit.js",
+    "audit": "npm audit --json | node scripts/audit.js",
     "audit:urls": "node scripts/audit-urls.js",
     "sharetribe": "sharetribe-scripts fetch",
     "clean": "rm -rf build/*",
@@ -105,9 +106,9 @@
     "config-check": "node scripts/config.js --check",
     "dev-frontend": "sharetribe-scripts start",
     "dev-backend": "nodemon server/apiServer.js",
-    "dev": "yarn run config-check&&cross-env NODE_ENV=development REACT_APP_DEV_API_SERVER_PORT=3500 concurrently --kill-others \"yarn run dev-frontend\" \"yarn run dev-backend\"",
+    "dev": "npm run config-check && cross-env NODE_ENV=development REACT_APP_DEV_API_SERVER_PORT=3500 concurrently --kill-others \"npm run dev-frontend\" \"npm run dev-backend\"",
     "prebuild": "node scripts/ensure-favicon.js",
-    "build": "yarn build-web && yarn build-server",
+    "build": "npm run build-web && npm run build-server",
     "postbuild": "node scripts/check-built-index.js && node scripts/check-icons.js",
     "build-web": "sharetribe-scripts build",
     "build-server": "sharetribe-scripts build-server",
@@ -115,15 +116,16 @@
     "format-ci": "prettier --list-different '**/*.{js,css}'",
     "format-docs": "prettier --write '**/*.md'",
     "test": "NODE_ICU_DATA=node_modules/full-icu sharetribe-scripts test",
-    "test-ci": "yarn run test-server --runInBand && sharetribe-scripts test --runInBand",
+    "test-ci": "npm run test-server --runInBand && sharetribe-scripts test --runInBand",
     "eject": "sharetribe-scripts eject",
     "start": "node --icu-data-dir=node_modules/full-icu server/index.js",
-    "dev-server": "cross-env-shell NODE_ENV=development PORT=4000 REACT_APP_MARKETPLACE_ROOT_URL=http://localhost:4000 \"yarn run build&&nodemon --watch server server/index.js\"",
+    "dev-server": "cross-env-shell NODE_ENV=development PORT=4000 REACT_APP_MARKETPLACE_ROOT_URL=http://localhost:4000 \"npm run build && nodemon --watch server server/index.js\"",
     "test-server": "jest ./server/**/*.test.js",
-    "heroku-postbuild": "yarn run build",
-    "render-build": "yarn run build",
+    "heroku-postbuild": "npm run build",
+    "render-build": "npm run build",
     "postinstall": "patch-package",
-    "translate": "node scripts/translations.js"
+    "translate": "node scripts/translations.js",
+    "jobs:reminders": "node server/scripts/sendShipByReminders.js"
   },
   "browserslist": {
     "production": [

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ import configureStore from './store';
 import { RouteConfigurationProvider } from './context/routeConfigurationContext';
 import { ConfigurationProvider } from './context/configurationContext';
 import { mergeConfig } from './util/configHelpers';
+import { IS_TEST } from './util/envFlags';
 import { IntlProvider } from './util/reactIntl';
 import { includeCSSProperties } from './util/style';
 import { IncludeScripts } from './util/includeScripts';
@@ -96,7 +97,7 @@ const addMissingTranslations = (sourceLangTranslations, targetLangTranslations) 
 // Note: Locale should not affect the tests. We ensure this by providing
 //       messages with the key as the value of each message and discard the value.
 //       { 'My.translationKey1': 'My.translationKey1', 'My.translationKey2': 'My.translationKey2' }
-const isTestEnv = process.env.NODE_ENV === 'test';
+const isTestEnv = IS_TEST;
 const localeMessages = isTestEnv
   ? mapValues(defaultMessages, (val, key) => key)
   : addMissingTranslations(defaultMessages, messagesInLocale);

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -5,10 +5,11 @@
 import appSettings from '../config/settings';
 import { types as sdkTypes, transit } from './sdkLoader';
 import Decimal from 'decimal.js';
+import { IS_DEV } from './envFlags';
 
 export const apiBaseUrl = marketplaceRootURL => {
   const port = process.env.REACT_APP_DEV_API_SERVER_PORT;
-  const useDevApiServer = process.env.NODE_ENV === 'development' && !!port;
+  const useDevApiServer = IS_DEV && !!port;
 
   // In development, the dev API server is running in a different port
   if (useDevApiServer) {

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -1,5 +1,6 @@
 import { subUnitDivisors } from '../config/settingsCurrency';
 import { getSupportedProcessesInfo } from '../transactions/transaction';
+import { IS_DEV } from './envFlags';
 
 // Generic helpers for validating config values
 
@@ -1105,7 +1106,7 @@ const union = (arr1, arr2, key) => {
 // Note: We don't want to expose this to production by default.
 //       If you customization relies on multiple listing types or custom listing fields, you need to change this.
 const mergeDefaultTypesAndFieldsForDebugging = isDebugging => {
-  const isDev = process.env.NODE_ENV === 'development';
+  const isDev = IS_DEV;
   return isDebugging && isDev;
 };
 

--- a/src/util/envFlags.js
+++ b/src/util/envFlags.js
@@ -1,0 +1,9 @@
+/**
+ * Centralized environment flags for client-side code
+ * Safely handles missing process object in browser environments
+ */
+
+export const IS_PROD = (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production');
+export const IS_DEV  = (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'development');
+export const IS_TEST = (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'test');
+export const __DEV__ = !IS_PROD;

--- a/src/util/googleMaps.js
+++ b/src/util/googleMaps.js
@@ -1,8 +1,9 @@
 import { types as sdkTypes } from '../util/sdkLoader';
+import { IS_DEV } from './envFlags';
 
 const { LatLng: SDKLatLng, LatLngBounds: SDKLatLngBounds } = sdkTypes;
 
-const isDev = process.env.NODE_ENV === 'development';
+const isDev = IS_DEV;
 
 /**
  * Extracts the geographic location (origin) from a Google Maps Place object


### PR DESCRIPTION
What: add envFlags, refactor client to IS_DEV/IS_TEST; normalize package.json scripts to npm; no dependency changes; keep build guards.

Why: prevent process in browser; standardize scripts; zero functional change.

How to test: npm ci && npm run build, load a page; CSP in report-only still OK.