### PR TITLE
9.2.1 — Clean exit for overdue cron (fixes "Timed out" false-failure)

### DIFF
--- a/server/scripts/sendOverdueReminders.js
+++ b/server/scripts/sendOverdueReminders.js
@@ -934,7 +934,15 @@ if (require.main === module) {
     // Run immediately for testing
     runDaily();
   } else {
-    sendOverdueReminders();
+    sendOverdueReminders()
+      .then(() => {
+        console.log('✅ Overdue reminders script complete, exiting.');
+        process.exit(0);
+      })
+      .catch(err => {
+        console.error('❌ Overdue reminders script failed:', err);
+        process.exit(1);
+      });
   }
 }
 


### PR DESCRIPTION
## Summary

One-line fix to the no-flag entry-point branch of
`sendOverdueReminders.js`. Previously the async work completed
successfully (candidates processed, SMS fired when applicable,
summary printed) but the process never exited — Redis + SDK
keep-alive connections held the event loop open until Render's
cron timeout force-killed the run. Every daily run showed
"Failed" in Render despite work completing. Daily
"cronjob failed" notification emails from Render were a side
effect.

Discovered during post-9.2 validation on April 21, 2026.

## Change

`server/scripts/sendOverdueReminders.js:936-938` — wrapped
`sendOverdueReminders()` call in `.then(process.exit(0))` /
`.catch(process.exit(1))`, matching the entry-point pattern
used by `sendAutoCancelUnshipped.js --once`.

## Verification

Post-deploy: click "Trigger Run" in Render dashboard for the
"Overdue / Late-Fee Reminders & Charges" cron. Expected:
run completes in <1 minute, Render event feed shows
"Successful run" (not Failed), stdout ends with
`✅ Overdue reminders script complete, exiting.` and exit code 0.

No regression test added — behavior change is process-lifecycle
only, verified by Render run status after deploy.

## Risk

Minimal. Only the no-flag else branch modified.
`--daemon` branch (self-scheduling) and `--test` branch are
untouched. Function body of `sendOverdueReminders()` is untouched.