### PR TITLE
PR-4 (10.0): 24h expire + lender escalation + watchdog + blocker fix

### DIFF
--- a/ext/transaction-processes/default-booking/process.edn
+++ b/ext/transaction-processes/default-booking/process.edn
@@ -74,7 +74,7 @@
    {:fn/min
     [{:fn/plus
       [{:fn/timepoint [:time/first-entered-state :state/preauthorized]}
-       {:fn/period ["P6D"]}]}
+       {:fn/period ["PT24H"]}]}
      {:fn/plus
       [{:fn/timepoint [:time/booking-start]} {:fn/period ["P1D"]}]}
      {:fn/timepoint [:time/booking-end]}]},

--- a/ext/transaction-processes/default-booking/process.edn.test.js
+++ b/ext/transaction-processes/default-booking/process.edn.test.js
@@ -1,0 +1,38 @@
+/**
+ * PR-4 (10.0): process.edn v5 — tighten transition/expire to 24h.
+ *
+ * Source-level assertion that the only change in the expire clause is
+ * P6D → PT24H, and the other two :fn/min branches (bookingStart + 1d,
+ * bookingEnd) are untouched.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const EDN = fs.readFileSync(
+  path.resolve(__dirname, 'process.edn'),
+  'utf8'
+);
+
+describe('PR-4: process.edn expire clause', () => {
+  test('P6D is gone from the expire clause', () => {
+    // The expire clause is the only place P6D appeared in v4. v5 drops it.
+    // Locate the transition/expire block, then check it doesn't contain P6D.
+    const expireBlock = EDN.match(/:transition\/expire[\s\S]*?:to :state\/expired/);
+    expect(expireBlock).not.toBeNull();
+    expect(expireBlock[0]).not.toMatch(/P6D/);
+  });
+
+  test('PT24H is present in the expire clause', () => {
+    const expireBlock = EDN.match(/:transition\/expire[\s\S]*?:to :state\/expired/);
+    expect(expireBlock[0]).toMatch(/\{:fn\/period \["PT24H"\]\}/);
+  });
+
+  test('the other two :fn/min branches (bookingStart + 1d, bookingEnd) are preserved', () => {
+    const expireBlock = EDN.match(/:transition\/expire[\s\S]*?:to :state\/expired/);
+    // P1D after booking-start still present
+    expect(expireBlock[0]).toMatch(/\[:time\/booking-start\]\}\s*\{:fn\/period \["P1D"\]\}/);
+    // booking-end timepoint still present
+    expect(expireBlock[0]).toMatch(/:fn\/timepoint \[:time\/booking-end\]/);
+  });
+});

--- a/server/api/initiate-privileged.copy.test.js
+++ b/server/api/initiate-privileged.copy.test.js
@@ -1,0 +1,30 @@
+/**
+ * PR-4 (10.0): initiate-privileged 1-SMS copy update.
+ *
+ * Source-level regression: confirms the operator-approved copy change
+ * landed correctly — comma (not period) after the listing title,
+ * and the 24h window language replaces the old "Tap to review & accept".
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, 'initiate-privileged.js');
+const src = fs.readFileSync(SCRIPT, 'utf8');
+
+describe('PR-4: 1-SMS copy', () => {
+  test('payout clause starts with a comma (not period)', () => {
+    // Operator-approved: comma after "${title}" before "You'll earn".
+    expect(src).toMatch(/message \+= `, You'll earn \$\{formattedPayout\}/);
+    // The old period pattern should be gone.
+    expect(src).not.toMatch(/message \+= `\. You'll earn/);
+  });
+
+  test('URL clause uses "You have 24hrs to accept"', () => {
+    expect(src).toMatch(/message \+= `\. You have 24hrs to accept: \$\{shortUrl\}`/);
+  });
+
+  test('old "Tap to review & accept" copy is gone', () => {
+    expect(src).not.toMatch(/Tap to review & accept:/);
+  });
+});

--- a/server/api/initiate-privileged.js
+++ b/server/api/initiate-privileged.js
@@ -46,15 +46,24 @@ async function buildLenderMsg(tx, listingTitle, borrowerFirstName, payoutTotal, 
   const title = listingTitle || 'your listing';
   const formattedPayout = payoutTotal ? formatMoneyServerSide(payoutTotal) : null;
   
-  // Build message with dynamic values
+  // Build message with dynamic values.
+  //
+  // 10.0 PR-4: operator-approved copy surfaces the 24h acceptance window at
+  // first contact, matching the v5 process.edn expire clause. Note the
+  // comma (not period) after the title — technical comma-splice but the
+  // approved template (April 23, 2026).
+  //
+  // Example final composed message:
+  //   Sherbrt 🍧: Monica wants to borrow your "Faille Halter Mini Dress",
+  //   You'll earn $48 💸🤑. You have 24hrs to accept: https://sherbrt.com/r/abc
   let message = `Sherbrt 🍧: ${firstName} wants to borrow your "${title}"`;
-  
+
   if (formattedPayout) {
-    message += `. You'll earn ${formattedPayout} 💸🤑`;
+    message += `, You'll earn ${formattedPayout} 💸🤑`;
   }
-  
-  message += `. Tap to review & accept: ${shortUrl}`;
-  
+
+  message += `. You have 24hrs to accept: ${shortUrl}`;
+
   return message;
 }
 

--- a/server/scripts/sendAutoCancelUnshipped.js
+++ b/server/scripts/sendAutoCancelUnshipped.js
@@ -133,17 +133,22 @@ async function processTransaction(tx, included, now, sdk) {
     return;
   }
 
-  // Process-version gate: transition/auto-cancel-unshipped only exists in
-  // default-booking v3 (pushed + aliased April 14, 2026). Transactions created
-  // under v1 or v2 can't accept this transition — firing it would return an
-  // "unknown transition" error. v1 txs can also have diverged booking/tx state
-  // (e.g., operator-declined booking while tx stays in accepted) because v1's
-  // state machine has no cancel-from-accepted path.
+  // Process-version gate: transition/auto-cancel-unshipped was introduced in
+  // default-booking v3 (April 14, 2026). Transactions on v1 or v2 can't accept
+  // this transition — firing it would return "unknown transition". v1 txs
+  // also have diverged booking/tx state (e.g., operator-declined booking
+  // while tx stays in accepted) because v1's state machine has no
+  // cancel-from-accepted path.
+  //
+  // 10.0 PR-4 fix: was `processVersion !== 3` (hard equality), which silently
+  // skipped every v5 transaction after the expire-tightening alias flip.
+  // Changed to `< 3` so v3, v4, v5, and any future bump all pass the gate
+  // while still excluding v1/v2.
   const processName = tx.attributes?.processName;
   const processVersion = tx.attributes?.processVersion;
-  if (processName !== TX_PROCESS || processVersion !== 3) {
+  if (processName !== TX_PROCESS || processVersion < 3) {
     console.log(
-      `${logPrefix} not on ${TX_PROCESS} v3 (process=${processName} v${processVersion}), skipping`
+      `${logPrefix} not on ${TX_PROCESS} v3+ (process=${processName} v${processVersion}), skipping`
     );
     return;
   }

--- a/server/scripts/sendAutoCancelUnshipped.version-gate.test.js
+++ b/server/scripts/sendAutoCancelUnshipped.version-gate.test.js
@@ -1,0 +1,99 @@
+/**
+ * PR-4 (10.0): sendAutoCancelUnshipped processVersion gate fix.
+ *
+ * The old gate was `processVersion !== 3` (hard equality). After the
+ * v5 alias flip, every new transaction has processVersion===5 and the
+ * cron silently skipped them all. Changed to `< 3` so v3/v4/v5/any
+ * future bump all pass while v1/v2 are still excluded.
+ *
+ * This test behaviorally confirms the new gate by invoking
+ * processTransaction with a v5 tx and asserting it does NOT short-circuit
+ * at the version-gate log line. Uses DRY_RUN=1 to avoid real SDK calls.
+ */
+
+process.env.AUTO_CANCEL_DRY_RUN = '1';
+
+const moment = require('moment-timezone');
+const { processTransaction } = require('./sendAutoCancelUnshipped');
+
+// Wednesday bookingStart + 13 hours past the cancel deadline → past the
+// scan-lag grace window, no outbound scan → should proceed to cancel path.
+const BOOKING_START_UTC = '2026-04-22T00:00:00.000Z';
+const DEADLINE_UTC = '2026-04-23T06:59:59.000Z';
+const pastDeadline = hours =>
+  moment.utc(DEADLINE_UTC).add(hours, 'hours').toDate();
+
+function makeTx({ processVersion }) {
+  return {
+    id: { uuid: 'test-tx-version' },
+    attributes: {
+      processName: 'default-booking',
+      processVersion,
+      protectedData: {},
+    },
+    relationships: {
+      booking: { data: { type: 'booking', id: { uuid: 'book-1' } } },
+      listing: { data: { type: 'listing', id: { uuid: 'list-1' } } },
+      customer: { data: { type: 'user', id: { uuid: 'cust-1' } } },
+      provider: { data: { type: 'user', id: { uuid: 'prov-1' } } },
+    },
+  };
+}
+
+const included = [
+  {
+    type: 'booking',
+    id: { uuid: 'book-1' },
+    attributes: { start: BOOKING_START_UTC, state: 'accepted' },
+  },
+  {
+    type: 'listing',
+    id: { uuid: 'list-1' },
+    attributes: {
+      title: 'Test Listing',
+      availabilityPlan: { timezone: 'America/Los_Angeles' },
+    },
+  },
+  {
+    type: 'user',
+    id: { uuid: 'cust-1' },
+    attributes: { profile: { protectedData: { phone: '+15550001111' } } },
+  },
+  {
+    type: 'user',
+    id: { uuid: 'prov-1' },
+    attributes: { profile: { protectedData: { phone: '+15550002222' } } },
+  },
+];
+
+const mockSdk = { transactions: { transition: jest.fn(() => Promise.resolve({})) } };
+
+describe('PR-4: processVersion gate accepts v3/v4/v5', () => {
+  let logSpy;
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockSdk.transactions.transition.mockClear();
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([3, 4, 5])('processVersion=%i passes the gate (reaches cancel path under DRY_RUN)', async (processVersion) => {
+    const now = pastDeadline(13); // past scan-lag grace
+    await processTransaction(makeTx({ processVersion }), included, now, mockSdk);
+    const logs = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    // If the old `!== 3` gate were still active, v4/v5 would short-circuit here.
+    expect(logs).not.toMatch(/not on default-booking v3\b/);
+    // Should reach the cancel firing path under DRY_RUN.
+    expect(logs).toMatch(/firing transition\/auto-cancel-unshipped \(dry=true\)/);
+  });
+
+  test.each([1, 2])('processVersion=%i is still rejected', async (processVersion) => {
+    const now = pastDeadline(13);
+    await processTransaction(makeTx({ processVersion }), included, now, mockSdk);
+    const logs = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(logs).toMatch(/not on default-booking v3\+/);
+    expect(logs).not.toMatch(/firing transition\/auto-cancel-unshipped/);
+  });
+});

--- a/server/scripts/sendLenderRequestReminders.js
+++ b/server/scripts/sendLenderRequestReminders.js
@@ -1,80 +1,85 @@
 #!/usr/bin/env node
 /**
- * Lender Request Reminder SMS Script (60-minute follow-up)
+ * Lender Request Reminder SMS Script — 2-phase escalation (10.0 PR-4)
  *
- * Sends a single follow-up SMS to the lender if they haven't accepted or
- * rejected a borrow request within 60 minutes of it being placed.
+ * Sends up to two follow-up SMS to the lender if they haven't accepted or
+ * rejected a borrow request within the 24-hour expiration window:
+ *   - 60m phase (gentle nudge)
+ *   - 22h phase (final warning, 2h before expiration)
  *
  * ──────────────────────────────────────────────────────────────────────────
  * WHY / WHAT
  * ──────────────────────────────────────────────────────────────────────────
  * A borrower creates a request and the lender is notified immediately via
- * the initial lender SMS (see server/api/initiate-privileged.js). If the
- * lender doesn't act, this worker nudges them once at ~60 minutes:
+ * the initial lender SMS (see server/api/initiate-privileged.js). Under
+ * the 10.0 24h expire window (process.edn v5), requests auto-expire at
+ * min(firstEnteredPreauthorized + 24h, bookingStart + 1d, bookingEnd).
  *
- *   "Sherbrt 🍧: Don't leave <FirstName> hanging! <$Earnings> is waiting
- *    for you! 🤑🤑🤑 Just tap to accept: <shortUrl>."
- *
- * Requests auto-expire (transition/expire) at min(
- *   firstEnteredPreauthorized + 6 days,
- *   bookingStart + 1 day,
- *   bookingEnd,
- * ), so the 60-minute window is always safely before auto-expire (minimum
- * floor is ≥ several hours in practice; we still re-check tx.state before
- * sending).
+ * If the lender doesn't act, this worker nudges them twice:
+ *   - 60m: "Don't leave ${first} hanging! ... Just tap before it expires"
+ *   - 22h: "⚠️ Final call — ${first}'s request expires in 2 hours."
  *
  * ──────────────────────────────────────────────────────────────────────────
- * 60–80 MINUTE WINDOW LOGIC
+ * PHASE WINDOWS
  * ──────────────────────────────────────────────────────────────────────────
- * The Render cron runs every 15 minutes. A naive "age > 60 min" filter
- * would keep matching the same tx on every subsequent run. We instead pick
- * transactions whose age is in [60, 80) minutes:
+ * Phases are non-overlapping age buckets evaluated per-tx per-cron-tick:
  *
- *   - Lower bound 60m: don't nudge too early.
- *   - Upper bound 80m: 60m + one 15m cron tick + 5m of slack for long
- *     runs / cron jitter. Anything older than 80m has either already been
- *     reminded on a prior run, or is stale enough that we let it go.
+ *   60m phase: [60m, 22h)   — gentle nudge
+ *   22h phase: [22h, 24h)   — final warning
  *
- * The window alone is not a correctness guarantee — it's a filter. The
- * real "send once" guarantee is the idempotency flag below.
+ * Each phase has its own Redis dedupe key, so a tx that passes through
+ * both windows on successive cron ticks gets exactly one SMS per phase
+ * (two total). Txs outside both windows are skipped.
  *
  * ──────────────────────────────────────────────────────────────────────────
- * IDEMPOTENCY CONTRACT (Redis-backed)
+ * QUIET-HOURS POLICY
  * ──────────────────────────────────────────────────────────────────────────
- * We use a "flag-before-send" pattern backed by Redis to eliminate any
- * risk of double-texting a lender. Redis (not protectedData) because the
- * Integration SDK we run under doesn't expose transactions.update — and
- * Redis is already used throughout the codebase (shortlinks, tracking,
- * return reminders) for exactly this kind of ephemeral cross-run state.
+ * The 60m phase respects the standard withinSendWindow gate (8am-11pm PT;
+ * out-of-window cron ticks defer until in-window, which works because the
+ * 60m window is 21 hours wide and absorbs any quiet-hours gap).
  *
- * Keys per transaction:
- *
- *   lenderReminder:{txId}:sent     (TTL 7 days)  → SMS already sent
- *   lenderReminder:{txId}:inFlight (TTL 10 min)  → a run is mid-send now
- *
- * Send sequence for each eligible tx:
- *
- *   1. If :sent exists → skip.
- *   2. If :inFlight exists → skip (another run — or a recently crashed
- *      run — is/was mid-send; 10-min TTL auto-clears a true crash).
- *   3. SET :inFlight with 10-min TTL.
- *   4. Call sendSMS().
- *   5a. On success → SET :sent (7-day TTL), DEL :inFlight.
- *   5b. On failure → DEL :inFlight so next cron tick can retry if still
- *       in the 60–80m window.
- *
- * If step 5 itself fails after a successful send, the inFlight key stays
- * until its 10-min TTL expires — by which point the tx has aged past the
- * 80m upper bound of the send window and will no longer be picked up, so
- * the lender is NOT re-texted.
+ * The 22h phase BYPASSES quiet-hours. Rationale: the phase window is only
+ * 2 hours wide. Borrowers who check out between 1am-3am PT would have
+ * their 22h final warning land entirely in the 11pm-1am PT quiet-hours
+ * block; by the time 8am rolls around, the tx has already expired and
+ * the warning is lost. A brief after-hours text when money is 2h from
+ * expiring is preferable to a silent miss (operator decision, April 23,
+ * 2026).
  *
  * ──────────────────────────────────────────────────────────────────────────
- * CRON SCHEDULING (Render/Heroku)
+ * IDEMPOTENCY CONTRACT (Redis-backed, per-phase)
+ * ──────────────────────────────────────────────────────────────────────────
+ * Keys per transaction per phase:
+ *
+ *   lenderReminder:{txId}:{phase}:sent     (TTL 7 days)
+ *   lenderReminder:{txId}:{phase}:inFlight (TTL 10 min)
+ *
+ * where {phase} is "60m" or "22h". The send sequence is per-phase:
+ *
+ *   1. If {phase}:sent exists → skip phase.
+ *   2. If {phase}:inFlight exists → skip (crash auto-clears at 10m).
+ *   3. SET {phase}:inFlight with 10-min TTL.
+ *   4. Call sendSMS() with phase-specific copy + tag.
+ *   5a. On success → SET {phase}:sent (7-day TTL), DEL {phase}:inFlight.
+ *   5b. On failure → DEL {phase}:inFlight so next cron tick can retry.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * MISSED_FINAL WATCHDOG (10.0 PR-4)
+ * ──────────────────────────────────────────────────────────────────────────
+ * After the main loop, a second query pass looks for transactions that
+ * transitioned to :state/expired within the last 30 minutes (two cron
+ * ticks) and checks whether their 22h:sent key exists in Redis. If not,
+ * the 22h final warning was missed and we log [MISSED_FINAL] for ops
+ * visibility. Steady-state: count=0; non-zero counts indicate clock skew,
+ * phase-boundary bugs, or other slippage worth investigating.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * CRON SCHEDULING (Render)
  * ──────────────────────────────────────────────────────────────────────────
  * Run every 15 minutes:
  *   *\/15 * * * * npm run worker:lender-request-reminders
  *
- * For local testing (no real SMS, no protectedData writes):
+ * Local testing (no real SMS, no Redis writes):
  *   npm run test:lender-request-reminders
  */
 require('dotenv').config();
@@ -110,15 +115,38 @@ const VERBOSE = has('--verbose') || process.env.VERBOSE === '1';
 const LIMIT = parseInt(getOpt('--limit', process.env.LIMIT || '0'), 10) || 0;
 const ONLY_PHONE = process.env.ONLY_PHONE;
 
-const MIN_AGE_MS = 60 * 60 * 1000; // 60 minutes
-// Wide upper bound: 13 hours covers any quiet-hours gap (11 PM → 8 AM = 9h,
-// plus margin). Txs older than 13h are genuinely stale. Previously 80 min;
-// widened for Pattern B quiet-hours support (see PR-3b spec §3b.3).
-const MAX_AGE_MS = 13 * 60 * 60 * 1000; // 13 hours (780 minutes)
-const INFLIGHT_TTL_SEC = 10 * 60; // 10 minutes — longer than any one SMS send
-const SENT_TTL_SEC = 7 * 24 * 60 * 60; // 7 days — comfortably outlasts 13h window
+// Full cron coverage of the 24h expiration window (10.0 PR-4).
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+const INFLIGHT_TTL_SEC = 10 * 60;       // 10 minutes — longer than any one SMS send
+const SENT_TTL_SEC = 7 * 24 * 60 * 60;  // 7 days — comfortably outlasts 24h window
+
+// 2-phase escalation: 60m gentle nudge, 22h final warning. Phase windows
+// are non-overlapping by construction — a tx in [60m, 22h) hits the 60m
+// phase only, [22h, 24h) hits the 22h phase only. Each phase has its own
+// Redis dedupe key so a tx surviving both windows gets exactly 2 SMS.
+//
+// 22h BYPASSES quiet-hours (bypassQuietHours: true); 60m respects it.
+const PHASES = [
+  {
+    key: '60m',
+    minAgeMs: 60 * 60 * 1000,      // 1 hour
+    maxAgeMs: 22 * 60 * 60 * 1000, // 22 hours
+    tag: 'lender_request_reminder_60m',
+    bypassQuietHours: false,
+  },
+  {
+    key: '22h',
+    minAgeMs: 22 * 60 * 60 * 1000, // 22 hours
+    maxAgeMs: 24 * 60 * 60 * 1000, // 24 hours
+    tag: 'lender_request_reminder_22h',
+    bypassQuietHours: true,
+  },
+];
 
 const redisKey = (txId, suffix) => `lenderReminder:${txId}:${suffix}`;
+
+// Compose the per-phase Redis key suffix (e.g., "60m:sent", "22h:inFlight").
+const phaseKey = (phase, kind) => `${phase.key}:${kind}`;
 
 const REQUEST_TRANSITIONS = new Set([
   'transition/request-payment',
@@ -142,31 +170,36 @@ if (DRY) {
 }
 
 /**
- * Redis-backed idempotency helpers. No-op writes in DRY mode.
+ * Redis-backed idempotency helpers — per-phase. No-op writes in DRY mode.
+ * `phase` is a PHASES entry; keys resolve to e.g. "lenderReminder:{txId}:60m:sent".
  */
-async function markInFlight(redis, txId) {
+async function markInFlight(redis, txId, phase) {
+  const key = redisKey(txId, phaseKey(phase, 'inFlight'));
   if (DRY) {
-    console.log(`[lender-request-reminder] DRY-RUN: Would SET ${redisKey(txId, 'inFlight')} (TTL ${INFLIGHT_TTL_SEC}s)`);
+    console.log(`[lender-request-reminder] DRY-RUN: Would SET ${key} (TTL ${INFLIGHT_TTL_SEC}s)`);
     return;
   }
-  await redis.set(redisKey(txId, 'inFlight'), new Date().toISOString(), 'EX', INFLIGHT_TTL_SEC);
+  await redis.set(key, new Date().toISOString(), 'EX', INFLIGHT_TTL_SEC);
 }
 
-async function clearInFlight(redis, txId) {
+async function clearInFlight(redis, txId, phase) {
+  const key = redisKey(txId, phaseKey(phase, 'inFlight'));
   if (DRY) {
-    console.log(`[lender-request-reminder] DRY-RUN: Would DEL ${redisKey(txId, 'inFlight')}`);
+    console.log(`[lender-request-reminder] DRY-RUN: Would DEL ${key}`);
     return;
   }
-  await redis.del(redisKey(txId, 'inFlight'));
+  await redis.del(key);
 }
 
-async function markSent(redis, txId) {
+async function markSent(redis, txId, phase) {
+  const sentKey = redisKey(txId, phaseKey(phase, 'sent'));
+  const inFlightKey = redisKey(txId, phaseKey(phase, 'inFlight'));
   if (DRY) {
-    console.log(`[lender-request-reminder] DRY-RUN: Would SET ${redisKey(txId, 'sent')} (TTL ${SENT_TTL_SEC}s)`);
+    console.log(`[lender-request-reminder] DRY-RUN: Would SET ${sentKey} (TTL ${SENT_TTL_SEC}s)`);
     return;
   }
-  await redis.set(redisKey(txId, 'sent'), new Date().toISOString(), 'EX', SENT_TTL_SEC);
-  await redis.del(redisKey(txId, 'inFlight'));
+  await redis.set(sentKey, new Date().toISOString(), 'EX', SENT_TTL_SEC);
+  await redis.del(inFlightKey);
 }
 
 async function sendLenderRequestReminders() {
@@ -269,7 +302,7 @@ async function sendLenderRequestReminders() {
         continue;
       }
 
-      // Age window: [60m, 80m)
+      // Age check + phase selection (10.0 PR-4).
       const createdAt = attrs.createdAt ? new Date(attrs.createdAt).getTime() : null;
       if (!createdAt) {
         if (VERBOSE) console.log(`[lender-request-reminder] Skipping tx ${txId} — no createdAt`);
@@ -277,30 +310,32 @@ async function sendLenderRequestReminders() {
         continue;
       }
       const ageMs = nowMs - createdAt;
-      if (ageMs < MIN_AGE_MS || ageMs >= MAX_AGE_MS) {
-        if (VERBOSE) console.log(`[lender-request-reminder] Skipping tx ${txId} — ageMin=${Math.round(ageMs / 60000)} out of window`);
+      // A tx can match at most one phase by construction (non-overlapping windows).
+      const phase = PHASES.find(p => ageMs >= p.minAgeMs && ageMs < p.maxAgeMs);
+      if (!phase) {
+        if (VERBOSE) console.log(`[lender-request-reminder] Skipping tx ${txId} — ageMin=${Math.round(ageMs / 60000)} in no phase window`);
         skipped++;
         continue;
       }
 
-      // Idempotency: inspect Redis flags
+      // Per-phase idempotency: inspect Redis flags for THIS phase only.
       let sentFlag = null;
       let inFlightFlag = null;
       try {
-        sentFlag = await redis.get(redisKey(txId, 'sent'));
-        inFlightFlag = await redis.get(redisKey(txId, 'inFlight'));
+        sentFlag = await redis.get(redisKey(txId, phaseKey(phase, 'sent')));
+        inFlightFlag = await redis.get(redisKey(txId, phaseKey(phase, 'inFlight')));
       } catch (redisErr) {
-        console.error(`[lender-request-reminder] Redis read failed for tx ${txId}, skipping to be safe:`, redisErr.message);
+        console.error(`[lender-request-reminder] Redis read failed for tx ${txId} phase=${phase.key}, skipping to be safe:`, redisErr.message);
         skipped++;
         continue;
       }
       if (sentFlag) {
-        if (VERBOSE) console.log(`[lender-request-reminder] Skipping tx ${txId} — already sent at ${sentFlag}`);
+        if (VERBOSE) console.log(`[lender-request-reminder] Skipping tx ${txId} phase=${phase.key} — already sent at ${sentFlag}`);
         skipped++;
         continue;
       }
       if (inFlightFlag) {
-        if (VERBOSE) console.log(`[lender-request-reminder] Skipping tx ${txId} — inFlight since ${inFlightFlag}`);
+        if (VERBOSE) console.log(`[lender-request-reminder] Skipping tx ${txId} phase=${phase.key} — inFlight since ${inFlightFlag}`);
         skipped++;
         continue;
       }
@@ -360,22 +395,27 @@ async function sendLenderRequestReminders() {
         console.warn(`[lender-request-reminder] shortLink failed for tx ${txId}, using full URL:`, e.message);
       }
 
-      const message = `Sherbrt 🍧: Don't leave ${borrowerFirstName} hanging! ${formattedPayout} is waiting for you! 🤑🤑🤑 Just tap to accept: ${shortUrl}.`;
+      // Per-phase SMS copy (operator-approved, 2026-04-23).
+      const message = phase.key === '60m'
+        ? `Sherbrt 🍧: Don't leave ${borrowerFirstName} hanging! ${formattedPayout} is waiting for you! 🤑🤑🤑 Just tap before it expires: ${shortUrl}.`
+        : `Sherbrt 🍧: ⚠️ Final call — ${borrowerFirstName}'s request expires in 2 hours. After that, ${formattedPayout} is gone. Tap to accept now: ${shortUrl}`;
 
       const listingRef = tx?.relationships?.listing?.data;
       const listingId = listingRef?.id?.uuid || listingRef?.id || null;
 
-      // Step 1: flag inFlight BEFORE sending (10-min TTL auto-clears on crash)
-      // Quiet-hours gate: 8 AM – 11 PM PT (Pattern B — wide upper bound defers, not skips)
-      if (!withinSendWindow(getNow())) {
-        console.log(`[lender-request-reminder][QUIET-HOURS] tx=${txId} age=${Math.round(ageMs / 60000)}m — deferred`);
+      // Quiet-hours gate: applies to 60m phase only. 22h bypasses — a
+      // brief after-hours text when money is 2h from expiring beats a
+      // silent miss (operator decision, April 23, 2026).
+      if (!phase.bypassQuietHours && !withinSendWindow(getNow())) {
+        console.log(`[lender-request-reminder][QUIET-HOURS] tx=${txId} phase=${phase.key} age=${Math.round(ageMs / 60000)}m — deferred`);
         continue;
       }
 
+      // Step 1: flag inFlight BEFORE sending (10-min TTL auto-clears on crash).
       try {
-        await markInFlight(redis, txId);
+        await markInFlight(redis, txId, phase);
       } catch (flagErr) {
-        console.error(`[lender-request-reminder] Failed to write inFlight flag for tx ${txId}, skipping:`, flagErr.message);
+        console.error(`[lender-request-reminder] Failed to write inFlight flag for tx ${txId} phase=${phase.key}, skipping:`, flagErr.message);
         failed++;
         continue;
       }
@@ -385,26 +425,25 @@ async function sendLenderRequestReminders() {
       try {
         smsResult = await sendSMS(providerPhone, message, {
           role: 'lender',
-          tag: 'lender_request_reminder_60m',
-          meta: { transactionId: txId, listingId },
+          tag: phase.tag,
+          meta: { transactionId: txId, listingId, phase: phase.key },
         });
       } catch (smsErr) {
-        console.error(`[lender-request-reminder] SMS failed for tx ${txId}:`, smsErr?.message || smsErr);
-        // Rollback: clear inFlight so next cron tick can retry (if still in window)
+        console.error(`[lender-request-reminder] SMS failed for tx ${txId} phase=${phase.key}:`, smsErr?.message || smsErr);
+        // Rollback: clear inFlight so next cron tick can retry (if still in window).
         try {
-          await clearInFlight(redis, txId);
+          await clearInFlight(redis, txId, phase);
         } catch (rollbackErr) {
-          console.error(`[lender-request-reminder] Rollback DEL failed for tx ${txId}:`, rollbackErr.message);
+          console.error(`[lender-request-reminder] Rollback DEL failed for tx ${txId} phase=${phase.key}:`, rollbackErr.message);
         }
         failed++;
         continue;
       }
 
       if (smsResult?.skipped) {
-        // sendSMS decided not to send (e.g. suppression). Clear inFlight without marking sent.
-        console.log(`[lender-request-reminder] SMS skipped by sendSMS (${smsResult.reason}) for tx ${txId}`);
+        console.log(`[lender-request-reminder] SMS skipped by sendSMS (${smsResult.reason}) for tx ${txId} phase=${phase.key}`);
         try {
-          await clearInFlight(redis, txId);
+          await clearInFlight(redis, txId, phase);
         } catch (e) {
           console.error(`[lender-request-reminder] Failed to clear inFlight after sendSMS skip:`, e.message);
         }
@@ -412,15 +451,15 @@ async function sendLenderRequestReminders() {
         continue;
       }
 
-      // Step 3: mark sent. If this write fails, inFlight stays set until its
-      // 10-min TTL expires — by then the tx has aged past the 80m window and
-      // won't be picked up again. No double-text.
+      // Step 3: mark sent. If this write fails, inFlight stays set until
+      // its 10-min TTL expires — by then the tx has aged past the phase
+      // window and won't re-enter this branch. No double-text.
       try {
-        await markSent(redis, txId);
+        await markSent(redis, txId, phase);
         sent++;
-        console.log(`[lender-request-reminder] Sent reminder for tx ${txId}`);
+        console.log(`[lender-request-reminder] Sent ${phase.key} reminder for tx ${txId}`);
       } catch (postWriteErr) {
-        console.error(`[lender-request-reminder] SMS sent but Redis SET :sent failed for tx ${txId} — inFlight will TTL-expire after 80m window:`, postWriteErr.message);
+        console.error(`[lender-request-reminder] SMS sent but Redis SET :${phase.key}:sent failed for tx ${txId} — inFlight will TTL-expire:`, postWriteErr.message);
         sent++;
       }
 
@@ -428,6 +467,45 @@ async function sendLenderRequestReminders() {
         console.log(`[lender-request-reminder] Limit reached (${LIMIT}). Stopping.`);
         break;
       }
+    }
+
+    // MISSED_FINAL watchdog (10.0 PR-4). After the main loop, query for
+    // transactions that transitioned to :state/expired in the last 30 min
+    // (two 15-min cron ticks) and confirm their 22h:sent key exists in
+    // Redis. Missing keys mean the 22h final warning was lost — typically
+    // due to clock skew, phase-boundary miscalculation, or a cron outage.
+    // Steady-state log: [MISSED_FINAL_SUMMARY] count=0.
+    const WATCHDOG_LOOKBACK_MS = 30 * 60 * 1000;
+    const expireWindow = new Date(Date.now() - WATCHDOG_LOOKBACK_MS);
+
+    try {
+      const expiredResp = await sdk.transactions.query({
+        lastTransitions: 'transition/expire',
+        // Sharetribe's query API doesn't filter on lastTransitionedAt
+        // server-side; we over-fetch and filter client-side below.
+        per_page: 50,
+      });
+      let missedFinalCount = 0;
+      for (const tx of expiredResp?.data?.data || []) {
+        const lastAt = tx?.attributes?.lastTransitionedAt;
+        if (!lastAt || new Date(lastAt) < expireWindow) continue;
+        const txId = tx?.id?.uuid || tx?.id;
+        let twentyTwoSent = null;
+        try {
+          twentyTwoSent = await redis.get(redisKey(txId, '22h:sent'));
+        } catch (redisErr) {
+          console.warn(`[lender-request-reminder][WATCHDOG] Redis read failed for tx=${txId}:`, redisErr.message);
+          continue;
+        }
+        if (!twentyTwoSent) {
+          console.log(`[lender-request-reminder][MISSED_FINAL] tx=${txId} — expired without 22h warning fired`);
+          missedFinalCount++;
+        }
+      }
+      console.log(`[lender-request-reminder][MISSED_FINAL_SUMMARY] count=${missedFinalCount} lookbackMs=${WATCHDOG_LOOKBACK_MS}`);
+    } catch (watchdogErr) {
+      // Watchdog failures must not block the main cron. Log and continue.
+      console.warn('[lender-request-reminder][WATCHDOG_ERROR]', watchdogErr?.message || watchdogErr);
     }
 
     console.log(`\n[lender-request-reminder] Done. Sent=${sent} Skipped=${skipped} Failed=${failed} Processed=${processed}`);

--- a/server/scripts/sendLenderRequestReminders.js
+++ b/server/scripts/sendLenderRequestReminders.js
@@ -73,6 +73,11 @@
  * visibility. Steady-state: count=0; non-zero counts indicate clock skew,
  * phase-boundary bugs, or other slippage worth investigating.
  *
+ * Per-tx dedupe: because the 30-min lookback overlaps two consecutive
+ * 15-min cron ticks, each missed-final tx would otherwise log on both
+ * ticks. A Redis key `lenderReminder:{txId}:missedFinal:logged` (1h TTL)
+ * ensures we log + count exactly once per occurrence.
+ *
  * ──────────────────────────────────────────────────────────────────────────
  * CRON SCHEDULING (Render)
  * ──────────────────────────────────────────────────────────────────────────
@@ -116,9 +121,14 @@ const LIMIT = parseInt(getOpt('--limit', process.env.LIMIT || '0'), 10) || 0;
 const ONLY_PHONE = process.env.ONLY_PHONE;
 
 // Full cron coverage of the 24h expiration window (10.0 PR-4).
-const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
-const INFLIGHT_TTL_SEC = 10 * 60;       // 10 minutes — longer than any one SMS send
-const SENT_TTL_SEC = 7 * 24 * 60 * 60;  // 7 days — comfortably outlasts 24h window
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;             // 24 hours
+const INFLIGHT_TTL_SEC = 10 * 60;                   // 10 minutes — longer than any one SMS send
+const SENT_TTL_SEC = 7 * 24 * 60 * 60;              // 7 days — comfortably outlasts 24h window
+// The watchdog's 30-min lookback window overlaps across two consecutive
+// cron ticks, so a single missed-final tx would otherwise log twice.
+// 1h TTL is long enough to cover the lookback window with margin and
+// short enough to free the key before the next day's possible recurrence.
+const MISSED_FINAL_DEDUPE_TTL_SEC = 60 * 60;        // 1 hour
 
 // 2-phase escalation: 60m gentle nudge, 22h final warning. Phase windows
 // are non-overlapping by construction — a tx in [60m, 22h) hits the 60m
@@ -498,8 +508,30 @@ async function sendLenderRequestReminders() {
           continue;
         }
         if (!twentyTwoSent) {
+          // Dedupe across consecutive cron ticks: the 30-min lookback
+          // window overlaps the 15-min tick interval, so a single missed
+          // tx would otherwise log on two ticks and inflate count by 2x.
+          // 1h TTL is the cheapest fix (scope doc v3.1 step 7 spec).
+          const dedupeKey = redisKey(txId, 'missedFinal:logged');
+          let alreadyLogged = null;
+          try {
+            alreadyLogged = await redis.get(dedupeKey);
+          } catch (redisErr) {
+            console.warn(`[lender-request-reminder][WATCHDOG] Dedupe read failed for tx=${txId}, logging anyway:`, redisErr.message);
+          }
+          if (alreadyLogged) {
+            // Already counted on a prior tick; skip silently.
+            continue;
+          }
           console.log(`[lender-request-reminder][MISSED_FINAL] tx=${txId} — expired without 22h warning fired`);
           missedFinalCount++;
+          if (!DRY) {
+            try {
+              await redis.set(dedupeKey, new Date().toISOString(), 'EX', MISSED_FINAL_DEDUPE_TTL_SEC);
+            } catch (redisErr) {
+              console.warn(`[lender-request-reminder][WATCHDOG] Dedupe write failed for tx=${txId}:`, redisErr.message);
+            }
+          }
         }
       }
       console.log(`[lender-request-reminder][MISSED_FINAL_SUMMARY] count=${missedFinalCount} lookbackMs=${WATCHDOG_LOOKBACK_MS}`);

--- a/server/scripts/sendLenderRequestReminders.phases.test.js
+++ b/server/scripts/sendLenderRequestReminders.phases.test.js
@@ -1,0 +1,158 @@
+/**
+ * PR-4 (10.0): sendLenderRequestReminders 2-phase escalation.
+ *
+ * Source-level regression suite covering:
+ *   - PHASES array structure (60m + 22h, bypassQuietHours only on 22h)
+ *   - MAX_AGE_MS widened from 13h to 24h
+ *   - per-phase Redis keys (lenderReminder:{txId}:60m:sent vs :22h:sent)
+ *   - 22h SMS copy contains "Final call" and 2-hour expiration language
+ *   - 60m SMS copy has the updated "before it expires" wording
+ *   - quiet-hours bypass only for 22h phase
+ *   - MISSED_FINAL watchdog query exists
+ *   - stale 6-day references removed from doc block
+ *
+ * The script is tightly coupled to the Integration SDK + Redis + sendSMS
+ * + Flex query API — a full behavioral test harness would need heavy
+ * mocking. Source-level assertions lock in the structural correctness
+ * that scope review found critical; prod dry-run smoke tests cover the
+ * end-to-end path.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, 'sendLenderRequestReminders.js');
+const src = fs.readFileSync(SCRIPT, 'utf8');
+
+describe('PR-4: PHASES array structure', () => {
+  test('PHASES is defined with 60m and 22h entries', () => {
+    expect(src).toMatch(/const PHASES\s*=\s*\[/);
+    expect(src).toMatch(/key:\s*'60m'/);
+    expect(src).toMatch(/key:\s*'22h'/);
+  });
+
+  test('60m phase window is [60 min, 22h)', () => {
+    // Tolerate inline // comments between fields in the PHASES literal.
+    const match = src.match(/key:\s*'60m'[\s\S]*?minAgeMs:\s*([^,\n]+)[\s\S]*?maxAgeMs:\s*([^,\n]+)/);
+    expect(match).not.toBeNull();
+    const minMs = Function(`return (${match[1]})`)();
+    const maxMs = Function(`return (${match[2]})`)();
+    expect(minMs).toBe(60 * 60 * 1000);
+    expect(maxMs).toBe(22 * 60 * 60 * 1000);
+  });
+
+  test('22h phase window is [22h, 24h)', () => {
+    const match = src.match(/key:\s*'22h'[\s\S]*?minAgeMs:\s*([^,\n]+)[\s\S]*?maxAgeMs:\s*([^,\n]+)/);
+    expect(match).not.toBeNull();
+    const minMs = Function(`return (${match[1]})`)();
+    const maxMs = Function(`return (${match[2]})`)();
+    expect(minMs).toBe(22 * 60 * 60 * 1000);
+    expect(maxMs).toBe(24 * 60 * 60 * 1000);
+  });
+
+  test('22h phase has bypassQuietHours: true; 60m does not', () => {
+    // 22h bypasses
+    const twentyTwoBlock = src.match(/key:\s*'22h'[\s\S]{0,400}?bypassQuietHours:\s*true/);
+    expect(twentyTwoBlock).not.toBeNull();
+    // 60m does NOT bypass
+    const sixtyBlock = src.match(/key:\s*'60m'[\s\S]{0,400}?bypassQuietHours:\s*false/);
+    expect(sixtyBlock).not.toBeNull();
+  });
+
+  test('per-phase SMS tags are 60m and 22h (no 12h)', () => {
+    expect(src).toMatch(/tag:\s*'lender_request_reminder_60m'/);
+    expect(src).toMatch(/tag:\s*'lender_request_reminder_22h'/);
+    expect(src).not.toMatch(/lender_request_reminder_12h/);
+  });
+});
+
+describe('PR-4: MAX_AGE_MS widened to 24h', () => {
+  test('MAX_AGE_MS is 24 hours, not 13', () => {
+    const match = src.match(/const MAX_AGE_MS\s*=\s*([^;]+);/);
+    expect(match).not.toBeNull();
+    const value = Function(`return (${match[1]})`)();
+    expect(value).toBe(24 * 60 * 60 * 1000);
+  });
+
+  test('no reference to 13 hours or 13h MAX remains in active code', () => {
+    // Allow the v1 comment about "Widened for Pattern B" to be removed;
+    // assert the stale constant value is gone from active code.
+    expect(src).not.toMatch(/const MAX_AGE_MS\s*=\s*13\s*\*/);
+  });
+});
+
+describe('PR-4: per-phase Redis keys', () => {
+  test('phaseKey helper composes "{phase}:sent" / "{phase}:inFlight"', () => {
+    expect(src).toMatch(/phaseKey\s*=\s*\(phase,\s*kind\)\s*=>\s*`\$\{phase\.key\}:\$\{kind\}`/);
+  });
+
+  test('markInFlight, markSent, clearInFlight all take a phase argument', () => {
+    expect(src).toMatch(/async function markInFlight\(redis,\s*txId,\s*phase\)/);
+    expect(src).toMatch(/async function markSent\(redis,\s*txId,\s*phase\)/);
+    expect(src).toMatch(/async function clearInFlight\(redis,\s*txId,\s*phase\)/);
+  });
+
+  test('legacy single-key redisKey(txId, "sent") / ("inFlight") calls are gone', () => {
+    // Watchdog reads redisKey(txId, '22h:sent') which is the per-phase shape;
+    // that's allowed. The bare "sent" and "inFlight" suffixes should be gone.
+    expect(src).not.toMatch(/redisKey\(txId,\s*'sent'\)/);
+    expect(src).not.toMatch(/redisKey\(txId,\s*'inFlight'\)/);
+  });
+});
+
+describe('PR-4: SMS copy', () => {
+  test('60m message uses "before it expires" (not "to accept")', () => {
+    // Locate the 60m-branch template literal.
+    expect(src).toMatch(/Just tap before it expires/);
+    // And the old copy is gone.
+    expect(src).not.toMatch(/Just tap to accept:\s*\$\{shortUrl\}/);
+  });
+
+  test('22h message contains "Final call" and "expires in 2 hours"', () => {
+    expect(src).toMatch(/Final call/);
+    expect(src).toMatch(/expires in 2 hours/);
+  });
+});
+
+describe('PR-4: quiet-hours bypass', () => {
+  test('quiet-hours gate checks phase.bypassQuietHours', () => {
+    expect(src).toMatch(/!phase\.bypassQuietHours\s*&&\s*!withinSendWindow/);
+  });
+});
+
+describe('PR-4: MISSED_FINAL watchdog', () => {
+  test('watchdog query for transition/expire exists', () => {
+    expect(src).toMatch(/lastTransitions:\s*['"]transition\/expire['"]/);
+  });
+
+  test('watchdog checks redis.get("22h:sent") for each recently-expired tx', () => {
+    expect(src).toMatch(/redisKey\(txId,\s*['"]22h:sent['"]\)/);
+  });
+
+  test('MISSED_FINAL per-tx log + MISSED_FINAL_SUMMARY count log both present', () => {
+    expect(src).toMatch(/\[MISSED_FINAL\]/);
+    expect(src).toMatch(/\[MISSED_FINAL_SUMMARY\]/);
+  });
+
+  test('watchdog errors are caught and do not block main cron', () => {
+    expect(src).toMatch(/catch \(watchdogErr\)/);
+    expect(src).toMatch(/WATCHDOG_ERROR/);
+  });
+
+  test('watchdog lookback window is 30 minutes', () => {
+    expect(src).toMatch(/WATCHDOG_LOOKBACK_MS\s*=\s*30\s*\*\s*60\s*\*\s*1000/);
+  });
+});
+
+describe('PR-4: stale 6-day references removed', () => {
+  test('doc-block no longer references "P6D" or "6 days" for the expire window', () => {
+    // Allow the 6-days comment to be replaced by 24h language. Just make
+    // sure no code-level reference remains.
+    expect(src).not.toMatch(/firstEnteredPreauthorized \+ 6 days/);
+  });
+
+  test('doc-block mentions 24-hour window and 2-phase escalation', () => {
+    expect(src).toMatch(/24-hour expiration window|24 hour expiration window|24h/);
+    expect(src).toMatch(/2-phase escalation/);
+  });
+});

--- a/server/scripts/sendLenderRequestReminders.phases.test.js
+++ b/server/scripts/sendLenderRequestReminders.phases.test.js
@@ -142,6 +142,23 @@ describe('PR-4: MISSED_FINAL watchdog', () => {
   test('watchdog lookback window is 30 minutes', () => {
     expect(src).toMatch(/WATCHDOG_LOOKBACK_MS\s*=\s*30\s*\*\s*60\s*\*\s*1000/);
   });
+
+  test('per-tx dedupe key "missedFinal:logged" with 1h TTL prevents double-counting', () => {
+    // Scope doc v3.1 step 7: because the 30-min lookback window overlaps
+    // two 15-min cron ticks, the same missed tx would log twice without
+    // dedupe. Lock in the key name, TTL, and the read-before-log pattern.
+    expect(src).toMatch(/redisKey\(txId,\s*['"]missedFinal:logged['"]\)/);
+    expect(src).toMatch(/MISSED_FINAL_DEDUPE_TTL_SEC\s*=\s*60\s*\*\s*60/);
+    // The guard must check alreadyLogged BEFORE incrementing the count;
+    // otherwise dedupe is visual-only and the count still inflates.
+    expect(src).toMatch(/if \(alreadyLogged\)[\s\S]*?continue;[\s\S]*?\[MISSED_FINAL\][\s\S]*?missedFinalCount\+\+/);
+  });
+
+  test('dedupe write is skipped in DRY mode', () => {
+    // DRY mode should log but not write Redis keys — matches the
+    // existing markInFlight/markSent DRY behavior.
+    expect(src).toMatch(/if \(!DRY\)\s*\{[\s\S]*?redis\.set\(dedupeKey/);
+  });
 });
 
 describe('PR-4: stale 6-day references removed', () => {


### PR DESCRIPTION
Final PR of the 10.0 rollout. Tightens lender acceptance window from 6 days to 24 hours and ships the supporting pieces — plus a critical bug fix that would have silently broken auto-cancel after the v5 alias flip.

Scope: `docs/10.0_shippo_anchored_shipby.md` → PR-4

## ⚠️ BLOCKER FIX

`server/scripts/sendAutoCancelUnshipped.js:143` previously had `processVersion !== 3` (hard equality). After the v5 alias flip below, every new transaction would have `processVersion === 5` and auto-cancel would silently skip all of them — disabling the feature marketplace-wide. Changed to `processVersion < 3` so v3/v4/v5/future all pass. **Without this fix, the alias flip breaks auto-cancel for every new booking.**

## Process.edn change (requires flex-cli push)

Single-line change: `:transition/expire` clause period `P6D` → `PT24H`. Other two `:fn/min` branches (`bookingStart + 1d`, `bookingEnd`) unchanged.

**Deploy sequence AFTER merge + web code deploys:**
1. `flex-cli process push --process default-booking --path ext/transaction-processes/default-booking -m sherbrt`
2. `flex-cli process list --process default-booking -m sherbrt` — confirm v5 created, alias still v4
3. `flex-cli process update-alias --alias release-1 --process default-booking --version 5 -m sherbrt`
4. `flex-cli process list --process default-booking -m sherbrt` — confirm alias now v5

Web code works against both v4 (in-flight txs keep 6-day expire until completion) and v5 (new txs get 24h).

## Lender escalation system

Two-phase Redis-deduped reminders in `sendLenderRequestReminders.js`:
- **60m phase** — existing gentle nudge. Respects quiet-hours (8am-11pm PT).
- **22h phase (new)** — final warning at 22h age. **Bypasses quiet-hours** so it fires even at 2am PT. A brief after-hours text beats a silent miss when money is 2h from expiring.

Per-phase Redis keys: `lenderReminder:{txId}:60m:sent` and `lenderReminder:{txId}:22h:sent`. `MAX_AGE_MS` widened from 13h → 24h.

Per-phase SMS copy (operator-approved):
- 60m: "Sherbrt 🍧: Don't leave ${name} hanging! ${payout} is waiting for you! 🤑🤑🤑 Just tap before it expires: ${url}."
- 22h: "Sherbrt 🍧: ⚠️ Final call — ${name}'s request expires in 2 hours. After that, ${payout} is gone. Tap to accept now: ${url}"

## MISSED_FINAL watchdog

Second query pass in the cron fetches recently-expired transactions (30-min lookback, client-side time-filter since Sharetribe doesn't support server-side `lastTransitionedAt`) and logs `[MISSED_FINAL] tx=<uuid>` for any that expired without the `22h:sent` Redis key being set. Per-run summary: `[MISSED_FINAL_SUMMARY] count=N`.

Dedupe: `lenderReminder:{txId}:missedFinal:logged` (1h TTL) prevents a single miss from being double-counted across the two 15-min cron ticks within the 30-min lookback. Steady-state expected count is 0.

## 1-SMS copy update

`server/api/initiate-privileged.js`: initial lender SMS now surfaces the 24h window at first contact. Was `"Tap to review & accept"`, now `"You have 24hrs to accept"`. Also switches period to comma after item title per operator-approved copy.

## Commits

- `e624b1bb2` — core PR-4 implementation (2-phase escalation, watchdog, processVersion gate fix, 1-SMS copy, process.edn v5)
- `5f2e321cb` — follow-up: Redis dedupe for MISSED_FINAL log (prevents 2x count inflation for single misses)

## Pre-merge operator checklist

- [ ] Review Sharetribe Console → Content → Email templates → `booking-expired-request` for any stale "6 days" / "within a week" language. Update to 24h reference if needed. If the copy is already generic, no edit needed.

## Post-merge deploy steps (in order)

1. Merge PR (web code deploys via Render auto-deploy)
2. Run the 4 flex-cli commands above to push + flip v5 alias
3. Verify in Sharetribe Console → Build → Advanced → Transaction processes that `default-booking/release-1` alias points at v5

## Tests

- 33 new test assertions across 4 new test files (22 phase/watchdog/dedupe, 5 version-gate behavioral, 3 process.edn, 3 SMS copy)
- Full server sweep: 186/198 pass, 12 pre-existing unrelated failures unchanged

## Post-deploy verification

- Next Lender Request Reminders cron tick should show `[MISSED_FINAL_SUMMARY] count=0 lookbackMs=1800000`
- Create a test transaction after the alias flip:
  - 1-SMS body: "You have 24hrs to accept"
  - Don't accept it — confirm auto-expires at 24h with full borrower refund
  - No new SMS to lender on expire
  - Auto-cancel cron processes v5 txs without skipping