### PR TITLE
Add 1c-SMS borrower-expired notification + defensive state filter on …

### DIFF
--- a/CLAUDE_CONTEXT.md
+++ b/CLAUDE_CONTEXT.md
@@ -283,6 +283,259 @@ Address mapping: `line1` → `customerStreet`, `postalCode` → `customerZip`.
 
 ## Recent Fixes & Gotchas
 
+### May 7, 2026 — 4-issue SMS / inbox-copy fix-up (default-booking expire flows)
+
+**The bugs.** Three back-to-back transactions (`69f8e5ee-…`,
+`69f8e102-…`, `69f8db17-…`) booked end-date May 7 hit `:state/expired`
+because the lender never accepted. They surfaced four separate
+problems:
+
+1. **Spurious 8-SMS day-of-return reminder.** All three borrowers
+   received `⏰ Sherbrt 🍧: Today's the day for you to ship back …
+   Check your dashboard for return instructions.` (the
+   `return_reminder_today_no_label` branch in
+   `server/scripts/sendReturnReminders.js`). Should never fire — these
+   txns were never `:state/delivered`. The base query filters
+   `state: ONLY_STATE || 'delivered'`, but txns slipped through anyway
+   (root cause unclear; either Sharetribe state filter looser than we
+   assume, or namespaced-vs-bare state mismatch). 7-SMS T-1 reminder
+   correctly skipped because no `pd.returnQrUrl` / `pd.returnLabelUrl`
+   was ever generated (label only created on `transition/accept`).
+2. **No 1c-SMS for borrower on lender expire.** When
+   `transition/expire` fires (lender didn't accept in 24h), the
+   borrower got nothing. Borrowers were left wondering what happened.
+3. **Borrower inbox title was wrong.**
+   `customer.payment-expired.title` read "You didn't confirm the
+   payment in time" — borrower-blamey wording for a state that, while
+   technically about Stripe payment-intent timeout, often coincides
+   with operator-side workflow issues. Borrowers don't perceive
+   themselves as "confirming payment" — they tap Submit and wait.
+4. **Lender inbox title was wrong.**
+   `provider.payment-expired.title` read "Payment wasn't confirmed in
+   time" — implies the *borrower* failed, which confused lenders into
+   thinking this is a borrower-side problem. The lender perspective is
+   "I never got a chance to accept" — same outcome regardless of which
+   transition fired.
+
+**The fixes.**
+
+1. **Defensive state check inside the loop** in
+   `server/scripts/sendReturnReminders.js` (right after the ONLY_TX
+   filter). Re-checks `tx.attributes.state` against the expected state
+   (`ONLY_STATE || 'delivered'`), normalizing `state/delivered` →
+   `delivered` for Integration SDK responses. Skips with
+   `[RETURN-REMINDER][SKIP-WRONG-STATE]` log line. Belt-and-suspenders:
+   query filter remains the first line of defense; this catches
+   anything that slips past it. Cron tick on May 8+ should show this
+   skip path firing for any expired/canceled txns instead of sending.
+2. **1c-SMS borrower-expired notification** added to
+   `server/scripts/sendLenderRequestReminders.js`. The existing
+   `MISSED_FINAL` watchdog already polls
+   `lastTransitions: 'transition/expire'` every 15 min with a 30-min
+   lookback. Extended that same loop to:
+   - Add `include: ['customer']` to the watchdog query (was missing).
+   - Per tx within the lookback window, send a borrower SMS with copy:
+     `😔 Sherbrt 🍧: Your borrow request was not accepted this time.
+     Don't worry — there's still time to book another look you love!
+     Check them out now! https://www.sherbrt.com/r/lyBUNc13c1`
+   - Redis dedupe key
+     `lenderReminder:{txId}:borrowerExpired:sent` (7d TTL — outlasts
+     any reasonable retick window). DRY mode skips Redis writes.
+   - Tag: `borrower_request_expired`, smsNumber: `2c` in meta.
+   - Phone resolution mirrors the borrower-phone precedence used in
+     `sendReturnReminders.js`: checkout-protectedData phone wins over
+     profile phone (per Phase D task #31).
+   - Borrower-SMS failures are caught and logged — they must not
+     block `MISSED_FINAL` logging or subsequent txns.
+3. **`customer.payment-expired.title`** in
+   `src/translations/en.json`: `You didn't confirm the payment in
+   time.` → `Request expired.` Same change applied to the
+   `default-booking` entry only; `default-purchase` left as-is (not
+   used on Sherbrt).
+4. **`provider.payment-expired.title`** in `src/translations/en.json`:
+   `Payment wasn't confirmed in time.` → `Request not accepted.`
+   Same caveat — only the `default-booking` entry, not
+   `default-purchase`.
+
+**Why piggyback on `sendLenderRequestReminders` cron rather than a
+new transition hook.** `transition/expire` is an `:at`-driven
+transition fired by Sharetribe internally — there's no actor and no
+HTTP transition call hitting our `transition-privileged.js` handler.
+The only reliable way to react is polling, which the lender-request
+cron already does for its `MISSED_FINAL` watchdog. Reusing that loop
+keeps the moving parts to a minimum and inherits the existing 30-min
+lookback. Tradeoff: the borrower SMS lands up to ~30 min after the
+actual expire — acceptable given borrowers were waiting 24h+ already.
+
+**Note on `payment-expired` vs `expired` states.** Two separate
+states can lead to "request didn't go through":
+
+| State | Trigger | Cause |
+|-------|---------|-------|
+| `:state/payment-expired` | `transition/expire-payment` (15 min) | Stripe payment-intent confirmation timed out (borrower closed checkout / 3DS expired) |
+| `:state/expired` | `transition/expire` (24h or booking-start+1d or booking-end, whichever is earliest) | Lender didn't accept |
+
+The May 7 screenshots showed `payment-expired`-state titles, but the
+user reported lender-no-accept as the cause. Two possibilities: (a)
+borrowers actually didn't confirm Stripe in 15 min and the user
+mis-attributed the state, or (b) there's a state/title mapping issue
+worth a future investigation. Updating both `payment-expired` titles
+to the friendlier "Request expired" / "Request not accepted" copy is
+robust either way — neither blames the wrong party. The
+already-correct `expired`-state titles ("Your booking request
+expired." / "The request from {customerName} expired.") were left
+alone for now.
+
+**Future feature — 1c-EMAIL borrower-expired email.** The user
+explicitly scoped 1c-SMS only for now. Email companion (`1c-Email -
+Request expired`) is a tracked-here follow-up:
+- Source from `notification/booking-expired-request` in
+  `ext/transaction-processes/default-booking/process.edn`. Sharetribe
+  already has the notification wired (`:on :transition/expire`,
+  `:to :actor.role/customer`, template
+  `:booking-expired-request`); the *email template* itself in
+  Sharetribe Console → Content → Email templates is the place to
+  refresh copy.
+- Pending checklist item in CLAUDE_CONTEXT.md (line ~1295): "Review
+  Sharetribe Console → Content → Email templates →
+  `booking-expired-request` for stale '6 days' / 'within a week'
+  language. Update to '24 hours' or make generic." — combine with the
+  1c-EMAIL refresh.
+- Suggested copy mirroring the SMS:
+  `Subject: Your borrow request expired`
+  `Body: Your borrow request wasn't accepted this time. Don't worry —
+  more fabulous looks are waiting to be borrowed!
+  https://www.sherbrt.com/r/lyBUNc13c1`
+
+**Lender 24h auto-expire confirmed correct.** Per
+`ext/transaction-processes/default-booking/process.edn` the
+`transition/expire` `:at` clause is
+`min(firstEnteredPreauthorized + 24h, bookingStart + 1d, bookingEnd)`.
+For typical bookings (booking-start more than 1 day out) this is
+24h after the borrower confirms payment — matches the user's
+expectation. For last-minute bookings (booking-start within 24h of
+request) the window shrinks to `bookingStart + 1d` or `bookingEnd`,
+whichever is earliest, to avoid stranding the lender past their own
+booking. Already correct — no change needed.
+
+**Code commits (3, all on `main`):**
+- `<commit-1>` — `sendReturnReminders.js`: defensive
+  `[SKIP-WRONG-STATE]` check.
+- `<commit-2>` — `sendLenderRequestReminders.js`: 1c-SMS borrower
+  expired-request dispatch in watchdog loop. Extends watchdog query
+  with `include: ['customer']`. Adds Redis key
+  `lenderReminder:{txId}:borrowerExpired:sent` (7d TTL).
+- `<commit-3>` — `src/translations/en.json`: copy refresh on the two
+  `default-booking` `payment-expired.title` keys.
+
+**Verification.**
+- Local DRY run of `sendLenderRequestReminders.js` on a known expired
+  tx (e.g. one of the May 7 IDs) should show `[1c-SMS]` log lines
+  with `dryRun=true`.
+- Inspect `redis-cli get lenderReminder:69f8e5ee-…:borrowerExpired:sent`
+  after a real run — should be set.
+- Force a fake `state/canceled` tx through
+  `sendReturnReminders.js --verbose` — expect
+  `[RETURN-REMINDER][SKIP-WRONG-STATE]` log line, no SMS sent.
+- Inbox titles: visit a `payment-expired` tx as borrower and as
+  lender; confirm "Request expired." / "Request not accepted."
+
+**Open question for next session.** Why did the 8-SMS slip through
+the `state: 'delivered'` filter in the first place? The defensive
+check above prevents the symptom, but the root cause is still
+unidentified. Worth pulling production logs from the May 7 cron tick
+that sent the spurious SMS to confirm what state the Sharetribe
+query actually returned for those txns.
+
+**May 7, 2026 — addendum (Stripe forensics + workbook v13 + mobile
+sync).**
+
+*Stripe forensics on `pi_3TTQY7P9WqHTFi1C0VU20UjF` (one of the three
+May 7 txns).* PaymentIntent created May 4 10:44:55 AM, canceled May
+4 10:59:59 AM — exactly 15min04sec later. `amount_capturable=0`,
+`amount_received=0`, `payment_method=null`, `latest_charge=null`,
+`cancellation_reason=null`, `capture_method=manual`. Conclusion: the
+borrower never confirmed the PI (left checkout idle), Sharetribe
+fired `:transition/expire-payment` (PT15M from `:state/pending-payment`)
+which ran the `stripe-refund-payment` action and canceled the
+un-confirmed PI via API (no user-facing reason → `cancellation_reason`
+stays null; manual dashboard cancels would have set
+"requested_by_customer" or similar).
+
+*Implication.* These three May 7 txns died at `:state/payment-expired`
+(borrower checkout timeout), NOT `:state/expired` (lender no-accept).
+The `payment-expired` inbox titles were correctly displayed for the
+actual state. The user's mental model was off by one transition. The
+1c-SMS implemented in this fix-up fires on `:transition/expire`
+(lender-no-accept), so it would NOT have fired for the May 7 txns —
+those would need a separate "borrower abandoned checkout" SMS, which
+is out of scope for this entry. Logged as a future-feature candidate
+(see Future Comms tab in workbook v13). The defensive state check in
+`sendReturnReminders.js` IS still relevant for these txns — without
+it, future `payment-expired` txns slipping through the
+`state:'delivered'` filter would still trigger spurious 8-SMS.
+
+*Workbook v13.* Saved to
+`/Users/amaliabornstein/shop-on-sherbet-cursor/sherbrt_transaction_comms_v13.xlsx`.
+Two changes from v12:
+- Log tab: new row 1c-SMS inserted between 1b (22h final warning) and
+  2a (request accepted). 2c is already taken (return-label-provided)
+  so 1c was the cleaner numbering — extends the 1-series which is
+  the lender-accept-window flow. Summary tab COUNTIF/COUNTIFS ranges
+  bumped from `Log!C5:C29` → `Log!C5:C30` to absorb the inserted row.
+- New tab: Inbox Comms. Two-column matrix (Borrower / Lender) of
+  Sharetribe state → user-facing inbox title, sourced from
+  `src/translations/en.json` and mirrored against
+  `sherbrt-mobile/lib/transactions.ts`. 26 rows covering every
+  default-booking state for both perspectives. Includes the May 7
+  copy refresh, a column for the en.json key (so future edits know
+  what to grep for), and a column for the mobile equivalent so web
+  and mobile drift is visible at a glance.
+
+*Mobile app sync.* `sherbrt-mobile/lib/transactions.ts` had its own
+status-label dictionaries (`STATE_TO_STATUS` for borrower view,
+`STATE_TO_LENDER_STATUS` for lender view) that previously displayed
+"Payment didn't go through" for `payment-expired` on both sides.
+Updated to match web:
+- Borrower view: `Payment didn't go through` → `Request expired`
+- Lender view: `Payment didn't go through` → `Request not accepted`
+Comments added pointing back to the en.json keys + this CLAUDE_CONTEXT
+entry. The web and mobile labels will now stay in sync via the new
+Inbox Comms tab in v13.
+
+*Re-numbering ripple from 2c-SMS → 1c-SMS.* The first draft of this
+entry used 2c-SMS but 2c is already in workbook v12 (Return Label
+Provided, row 13). Renumbered everywhere: this entry's prose, the
+`smsNumber` meta field on the SMS dispatch, the doc-block comments
+in `sendLenderRequestReminders.js`, and the new workbook row
+identifier. The 1c-EMAIL future-feature companion follows the same
+naming.
+
+*Manual Stripe cancel handling — operator note.* If you ever cancel
+a Stripe PaymentIntent via the dashboard manually, you must ALSO
+cancel the corresponding Sharetribe transaction (Console →
+Transactions → tx → operator-cancel/decline) — they are independent
+systems. Canceling only in Stripe leaves Sharetribe in a stale
+`:state/preauthorized` (or `:state/pending-payment`), which means:
+later lender-accept attempts will fail at the
+`stripe-capture-payment-intent` action (PI is already canceled);
+1a-SMS / 1b-SMS reminders may still fire from the cron until the
+24h `transition/expire` lands; inbox / inbox titles will misrepresent
+the txn as live. Safest reset is decline on Sharetribe first
+(transition fires `stripe-refund-payment`, idempotent against an
+already-canceled PI), then verify Stripe matches.
+
+*Mobile rollout.* Server-side changes (`sendReturnReminders.js`
+state-skip + `sendLenderRequestReminders.js` 1c-SMS dispatch) live
+in the Render workers and fire for all clients regardless of
+platform — mobile users get the SMS just like web users. Inbox-title
+copy lives client-side, so:
+- Web (`shop-on-sherbet-cursor/src/translations/en.json`): updated.
+- Mobile (`sherbrt-mobile/lib/transactions.ts`): updated.
+The two are now in sync — but they're separate codebases, so future
+copy changes have to be made twice. The Inbox Comms tab in workbook
+v13 is the single source of truth for catching drift.
+
 ### May 1, 2026 — Shippo address validation (task #29)
 
 **The bug.** Two production accepts on 4/29/2026 (`69f28897-…` and

--- a/server/scripts/sendLenderRequestReminders.js
+++ b/server/scripts/sendLenderRequestReminders.js
@@ -482,23 +482,42 @@ async function sendLenderRequestReminders() {
       }
     }
 
-    // MISSED_FINAL watchdog (10.0 PR-4). After the main loop, query for
-    // transactions that transitioned to :state/expired in the last 30 min
-    // (two 15-min cron ticks) and confirm their 22h:sent key exists in
-    // Redis. Missing keys mean the 22h final warning was lost — typically
-    // due to clock skew, phase-boundary miscalculation, or a cron outage.
-    // Steady-state log: [MISSED_FINAL_SUMMARY] count=0.
+    // MISSED_FINAL watchdog (10.0 PR-4) + borrower-expired SMS dispatcher
+    // (May 7, 2026 — 1c-SMS). After the main loop, query for transactions
+    // that transitioned to :state/expired in the last 30 min (two 15-min
+    // cron ticks) and:
+    //   1. Confirm their 22h:sent key exists in Redis (MISSED_FINAL log).
+    //      Missing keys mean the 22h final warning was lost — typically
+    //      due to clock skew, phase-boundary miscalculation, or a cron
+    //      outage. Steady-state log: [MISSED_FINAL_SUMMARY] count=0.
+    //   2. Send the borrower a "request not accepted" SMS (1c-SMS) once
+    //      per tx, dedupe key `lenderReminder:{txId}:borrowerExpired:sent`
+    //      (7d TTL). Fires within 30 min of transition/expire — close
+    //      enough to the moment of expire for borrowers (vs. building a
+    //      separate cron). Includes a re-shop short link to the dresses
+    //      grid so they can book another look right away.
+    //      See sherbrt_transaction_comms_v13 → Log tab → 1c-SMS row.
     const WATCHDOG_LOOKBACK_MS = 30 * 60 * 1000;
     const expireWindow = new Date(Date.now() - WATCHDOG_LOOKBACK_MS);
+    const BORROWER_EXPIRED_RESHOP_LINK = 'https://www.sherbrt.com/r/lyBUNc13c1';
 
     try {
       const expiredResp = await sdk.transactions.query({
         lastTransitions: 'transition/expire',
+        // Include customer so we can resolve borrower phone for 1c-SMS.
+        include: ['customer'],
         // Sharetribe's query API doesn't filter on lastTransitionedAt
         // server-side; we over-fetch and filter client-side below.
         per_page: 50,
       });
+      // Build included map for customer lookup (mirrors main loop pattern).
+      const expiredIncluded = new Map();
+      for (const inc of expiredResp?.data?.included || []) {
+        const key = `${inc.type}/${inc.id?.uuid || inc.id}`;
+        expiredIncluded.set(key, inc);
+      }
       let missedFinalCount = 0;
+      let borrowerExpiredSmsSent = 0;
       for (const tx of expiredResp?.data?.data || []) {
         const lastAt = tx?.attributes?.lastTransitionedAt;
         if (!lastAt || new Date(lastAt) < expireWindow) continue;
@@ -536,8 +555,105 @@ async function sendLenderRequestReminders() {
             }
           }
         }
+
+        // 1c-SMS: borrower expired-request notification. Fires once per tx
+        // when transition/expire is observed in the watchdog window.
+        // Redis dedupe key is the source of truth (7d TTL outlasts any
+        // realistic re-tick window — `transition/expire` is terminal,
+        // tx can't re-fire it). DRY mode skips Redis writes.
+        //
+        // Quiet-hours: BYPASSED, same rationale as the 22h phase above.
+        // The watchdog's lookback window is only 30 min wide (2 cron
+        // ticks). A tx that hits expire during quiet hours (11pm-8am PT)
+        // would, if deferred, fall out of the lookback before the next
+        // in-window tick and the borrower SMS would be lost forever.
+        // Tradeoff vs 22h: 1c isn't time-critical (borrower can re-shop
+        // any time), but a silent miss is worse than a brief late-night
+        // text saying "your request wasn't accepted." Operator decision
+        // — flag here so the bypass is explicit.
+        try {
+          const borrowerSentKey = redisKey(txId, 'borrowerExpired:sent');
+          let alreadySent = null;
+          try {
+            alreadySent = await redis.get(borrowerSentKey);
+          } catch (redisErr) {
+            console.warn(`[lender-request-reminder][1c-SMS] Redis read failed for tx=${txId}:`, redisErr.message);
+            continue;
+          }
+          if (alreadySent) {
+            if (VERBOSE) console.log(`[lender-request-reminder][1c-SMS] tx=${txId} already sent at ${alreadySent}`);
+            continue;
+          }
+
+          // Resolve borrower phone — checkout protectedData wins over profile,
+          // matching the precedence used in sendReturnReminders.js. Mirrors
+          // its normalizePhoneCandidate() length check (>=7 chars) and emits
+          // the same [PHONE-SELECTED] log line for ops parity.
+          const normalizePhoneCandidate = (val) => {
+            const trimmed = val && String(val).trim();
+            if (!trimmed) return null;
+            return trimmed.length >= 7 ? trimmed : null;
+          };
+          const customerRef = tx?.relationships?.customer?.data;
+          const customerKey = customerRef ? `${customerRef.type}/${customerRef.id?.uuid || customerRef.id}` : null;
+          const customer = customerKey ? expiredIncluded.get(customerKey) : null;
+          const pd = tx?.attributes?.protectedData || {};
+          const checkoutPhone = normalizePhoneCandidate(
+            pd.customerPhone ||
+            pd.phone ||
+            pd.customer_phone ||
+            pd?.checkoutDetails?.customerPhone ||
+            pd?.checkoutDetails?.phone
+          );
+          const profilePhone = normalizePhoneCandidate(
+            customer?.attributes?.profile?.protectedData?.phoneNumber ||
+            customer?.attributes?.profile?.protectedData?.phone
+          );
+          const borrowerPhone = checkoutPhone || profilePhone || null;
+
+          if (!borrowerPhone) {
+            console.warn(`[lender-request-reminder][1c-SMS] tx=${txId} no borrower phone — skipping`);
+            continue;
+          }
+          if (ONLY_PHONE && borrowerPhone !== ONLY_PHONE) {
+            if (VERBOSE) console.log(`[lender-request-reminder][1c-SMS] tx=${txId} ONLY_PHONE filter — skipping`);
+            continue;
+          }
+          console.log(`[lender-request-reminder][1c-SMS][PHONE-SELECTED] tx=${txId} used=${checkoutPhone ? 'checkoutPhone(protectedData)' : 'profilePhone'}`);
+
+          const borrowerExpiredMessage =
+            `😔 Sherbrt 🍧: Your borrow request was not accepted this time. ` +
+            `Don't worry — there's still time to book another look you love!  ` +
+            `Check them out now! ${BORROWER_EXPIRED_RESHOP_LINK}`;
+
+          const smsResult = await sendSMS(borrowerPhone, borrowerExpiredMessage, {
+            role: 'customer',
+            tag: 'borrower_request_expired',
+            meta: { transactionId: txId, smsNumber: '1c' },
+          });
+
+          if (smsResult?.skipped) {
+            console.log(`[lender-request-reminder][1c-SMS] tx=${txId} skipped by sendSMS (${smsResult.reason})`);
+            continue;
+          }
+
+          if (!DRY) {
+            try {
+              await redis.set(borrowerSentKey, new Date().toISOString(), 'EX', SENT_TTL_SEC);
+            } catch (redisErr) {
+              console.warn(`[lender-request-reminder][1c-SMS] Redis SET sent flag failed for tx=${txId}:`, redisErr.message);
+            }
+          }
+          borrowerExpiredSmsSent++;
+          console.log(`[lender-request-reminder][1c-SMS] sent to borrower for tx=${txId}`);
+        } catch (borrowerSmsErr) {
+          // Borrower-SMS failures must not block missed-final logging or
+          // subsequent txns. Log and move on.
+          console.error(`[lender-request-reminder][1c-SMS] failed for tx=${txId}:`, borrowerSmsErr?.message || borrowerSmsErr);
+        }
       }
       console.log(`[lender-request-reminder][MISSED_FINAL_SUMMARY] count=${missedFinalCount} lookbackMs=${WATCHDOG_LOOKBACK_MS}`);
+      console.log(`[lender-request-reminder][BORROWER_EXPIRED_SMS_SUMMARY] sent=${borrowerExpiredSmsSent} lookbackMs=${WATCHDOG_LOOKBACK_MS}`);
     } catch (watchdogErr) {
       // Watchdog failures must not block the main cron. Log and continue.
       console.warn('[lender-request-reminder][WATCHDOG_ERROR]', watchdogErr?.message || watchdogErr);

--- a/server/scripts/sendReturnReminders.js
+++ b/server/scripts/sendReturnReminders.js
@@ -135,6 +135,19 @@ const DISABLE_RETURN_REMINDERS_FOR_TX =
   process.env.DISABLE_RETURN_REMINDERS_FOR_TX &&
   process.env.DISABLE_RETURN_REMINDERS_FOR_TX.trim();
 
+// Terminal states that should NEVER receive a return reminder. The base
+// query filter (state=delivered) is the primary gate; this set is a
+// defensive canary to make spurious traffic obvious in cron logs. Both
+// US ('canceled') and UK ('cancelled') spellings are accepted because
+// Sharetribe's API uses UK internally while our display layer uses US.
+const TERMINAL_STATES_DENYLIST = new Set([
+  'canceled',
+  'cancelled',
+  'declined',
+  'expired',
+  'payment-expired',
+]);
+
 function safeStringify(data, maxLen) {
   try {
     const s = JSON.stringify(data);
@@ -301,6 +314,28 @@ async function sendReturnReminders(allowExitOnError = true) {
         }
         if (ONLY_TX && txId !== ONLY_TX) {
           if (VERBOSE) console.log(`[RETURN-REMINDER-DEBUG] skipping non-target tx=${txId || '(no id)'} ONLY_TX=${ONLY_TX}`);
+          continue;
+        }
+
+        // Defensive state filter (added May 7, 2026 after spurious 8-SMS
+        // reminders fired for payment-expired/expired/canceled txns).
+        // Two layers:
+        //   1. Terminal-state denylist (canceled/cancelled/declined/expired/
+        //      payment-expired) → [SKIP-TERMINAL-STATE]. Loud log; if this
+        //      ever fires repeatedly the upstream query filter is broken.
+        //   2. Allowlist (state must equal expectedState) → [SKIP-WRONG-STATE].
+        //      Catches inquiry/pending-payment/preauthorized/accepted etc.
+        // Integration SDK returns "state/delivered"; marketplace SDK may
+        // return bare "delivered" — strip the "state/" prefix to accept both.
+        const expectedState = ONLY_STATE || 'delivered';
+        const txState = tx?.attributes?.state || '';
+        const normalizedTxState = txState.replace(/^state\//, '');
+        if (TERMINAL_STATES_DENYLIST.has(normalizedTxState)) {
+          console.log(`[RETURN-REMINDER][SKIP-TERMINAL-STATE] tx=${txId || '(no id)'} state=${txState} lastTransition=${tx?.attributes?.lastTransition || 'n/a'} — terminal state should never receive a return reminder. If this fires repeatedly, investigate upstream query filter.`);
+          continue;
+        }
+        if (normalizedTxState !== expectedState) {
+          console.log(`[RETURN-REMINDER][SKIP-WRONG-STATE] tx=${txId || '(no id)'} state=${txState} expected=${expectedState} lastTransition=${tx?.attributes?.lastTransition || 'n/a'}`);
           continue;
         }
 


### PR DESCRIPTION
…return reminders

Two coordinated cron-worker changes addressing the May 7, 2026 issue where canceled/expired txns received spurious 8-SMS day-of-return reminders, and borrowers received no notification when the lender let the 24h accept window run out.

server/scripts/sendReturnReminders.js
- Module-scope TERMINAL_STATES_DENYLIST (canceled/cancelled/declined/ expired/payment-expired) — explicit canary list of states that should never receive a return reminder.
- Two-layer defensive state filter inside the per-tx loop in processTxPage(): denylist ([SKIP-TERMINAL-STATE]) + allowlist ([SKIP-WRONG-STATE]). Belt-and-suspenders for the upstream state:'delivered' query filter; loud log makes filter-leak traffic obvious in cron output. Handles both Integration SDK ("state/ delivered") and Marketplace SDK ("delivered") shapes by stripping the namespace prefix.

server/scripts/sendLenderRequestReminders.js
- New 1c-SMS borrower-expired dispatcher inside the existing MISSED_FINAL watchdog loop. Reuses the watchdog's transition/expire query + 30-min lookback. Per-tx Redis dedupe key lenderReminder:{txId}:borrowerExpired:sent (7d TTL, terminal-state immutability makes this safe). Tag: borrower_request_expired.
- Watchdog query now includes ['customer'] for borrower phone resolution (purely additive; missed-final logic untouched).
- Phone resolution mirrors sendReturnReminders.js precedence (checkout protectedData > profile) with normalizePhoneCandidate length check + [PHONE-SELECTED] ops log for parity.
- Quiet-hours BYPASSED with explicit rationale: 30-min lookback means a deferred SMS during quiet hours is lost forever (same logic as the 22h phase).
- Failure isolation: outer try/catch around 1c block ensures any failure cannot regress missed-final logging.
- New [BORROWER_EXPIRED_SMS_SUMMARY] log alongside MISSED_FINAL_SUMMARY.

CLAUDE_CONTEXT.md: full forensics, root-cause notes, Stripe-event analysis (PI canceled at exactly 15min04sec → Sharetribe auto-expire- payment, not manual dashboard cancel), mobile-app checkout-flow hypothesis, future-feature note for 1c-EMAIL companion, and operator note on Stripe-vs-Sharetribe sync hygiene.

Workbook v13 (committed separately): new 1c-SMS row in Log tab, new Inbox Comms tab as web↔mobile drift source-of-truth.

Reviewed by Claude Code in two passes (sendReturnReminders.js state filter; sendLenderRequestReminders.js 1c-SMS dispatcher). Both passes returned "ship as-is"; CC nits applied (denylist hoisted to module scope, comment trim, 2c→1c rename, phone normalization parity, quiet-hours rationale comment). 30/30 existing tests pass.