### PR TITLE
Refresh 2a-SMS + 2b-SMS borrower copy to match workbook v13

### DIFF
--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -2709,12 +2709,13 @@ module.exports = async (req, res) => {
             buyerLink = fullOrderUrl;
           }
           
-          // Borrower acceptance SMS: always try if borrowerPhone exists
+          // Borrower acceptance SMS: always try if borrowerPhone exists.
+          // Copy refresh May 7, 2026 — aligned to workbook v13 2a-SMS row.
+          // Single-line, item-focused; providerName is no longer interpolated
+          // (still resolved above for any future use, but not in this string).
           if (borrowerPhone) {
             console.log('[sms] sending borrower_accept ...');
-            const borrowerMessage = `🎉 Your Sherbrt request was accepted! 🍧
-"${listingTitle}" from ${providerName} is confirmed. 
-You'll receive tracking info once it ships! ✈️👗 ${buyerLink}`;
+            const borrowerMessage = `🎉 Sherbrt 🍧: Your request for "${listingTitle}" was accepted! We'll share tracking once it ships. View details: ${buyerLink}.`;
             
             // Debug: log SMS length (Note: actual SMS segmentation depends on carrier encoding, newlines, etc.)
             console.log('[sms] borrower_accept length:', borrowerMessage.length, 'chars');
@@ -2786,25 +2787,14 @@ You'll receive tracking info once it ships! ✈️👗 ${buyerLink}`;
           console.log('🔍 Transition: transition/decline');
           
           if (borrowerPhone) {
-            // Build order page URL for borrower to view declined request (resilient to different ID shapes)
-            const tx = response?.data?.data;
-            const txIdForUrl = 
-              tx?.id?.uuid ||
-              transactionId?.uuid ||
-              transactionId ||
-              bodyParams?.params?.transactionId?.uuid;
-            const fullOrderUrl = orderUrl(txIdForUrl);
-            
-            // Use shortlink with defensive fallback
-            let declineLink;
-            try {
-              declineLink = await shortLink(fullOrderUrl);
-            } catch (err) {
-              console.warn('[sms] shortLink failed, using full URL:', err.message);
-              declineLink = fullOrderUrl;
-            }
-            
-            const message = `😔 Your Sherbrt request was declined. Don't worry — more fabulous looks are waiting to be borrowed! ${declineLink}`;
+            // Copy refresh May 7, 2026 — aligned to workbook v13 2b-SMS row.
+            // Switched from per-tx order URL (declineLink) to a static
+            // browse/re-shop link so the borrower lands on more inventory
+            // rather than the dead transaction view. Same link is used by
+            // 1c-SMS in sendLenderRequestReminders.js — refactor to env
+            // var BORROWER_RESHOP_URL is tracked as a follow-up in the
+            // May 7 backlog (CLAUDE_CONTEXT.md).
+            const message = `😔 Sherbrt 🍧: Your borrow request was declined. Don't worry — new looks are waiting to be borrowed! Check them out!  https://www.sherbrt.com/r/lyBUNc13c1.`;
             
             // Debug: log SMS length (Note: actual SMS segmentation depends on carrier encoding, newlines, etc.)
             console.log('[sms] borrower_decline length:', message.length, 'chars');


### PR DESCRIPTION
Aligns the in-code SMS copy with sherbrt_transaction_comms_v13.xlsx "Log" tab rows 9 (2a-SMS) and 11 (2b-SMS). Both fire from server/api/transition-privileged.js — same code path used by web and mobile lender-accept / lender-decline flows.

2a-SMS (tag: accept_to_borrower):
  New copy: Single-line, item-focused. listingTitle and buyerLink
  interpolated; providerName no longer used.

2b-SMS (tag: reject_to_borrower):
  New copy: Static browse/re-shop link instead of per-tx order
  URL. Same link as 1c-SMS in sendLenderRequestReminders.js.
  Removes now-unused fullOrderUrl / declineLink / shortLink call
  in the decline branch. Refactor to env var BORROWER_RESHOP_URL
  is tracked as follow-up #4 in the May 7 backlog.

Cross-platform: both web and mobile hit /api/transition-privileged when the lender taps Accept/Decline, so the new copy applies to both clients automatically.