### PR TITLE
feat(sms): defer lender booking-request SMS to preauthorized via even…

### DIFF
--- a/CLAUDE_CONTEXT.md
+++ b/CLAUDE_CONTEXT.md
@@ -283,6 +283,186 @@ Address mapping: `line1` → `customerStreet`, `postalCode` → `customerZip`.
 
 ## Recent Fixes & Gotchas
 
+### May 8, 2026 — Lender SMS deferred to preauthorized via Integration API events poller; borrower request-confirmation SMS removed
+
+**Surfaced.** Mobile dogfood on TestFlight build 0.1.0 (4): the lender
+1-SMS fired the moment the borrower tapped Pay in the Stripe
+PaymentSheet — i.e. on `transition/request-payment` — even when the
+PaymentSheet was abandoned and the tx died at `:state/payment-expired`
+(15min Stripe timeout). Lenders saw "Faille Halter Mini Dress —
+$48 💸🤑" notifications for bookings that never reached
+`:state/preauthorized`, eroding trust in the channel. Same dogfood
+also re-confirmed that the borrower confirmation SMS at
+`request-payment` (`booking_confirmation_to_borrower` tag) had been a
+silent no-op in practice — production logs show
+`customerId: undefined, borrowerPhone: null skip` consistently — so
+borrowers were never receiving an SMS confirming an action they had
+just taken on-screen anyway.
+
+**Industry pattern.** Airbnb / DoorDash / Uber Eats all defer
+host/lender notifications until payment authorization succeeds, not
+when the customer first taps the pay button. The
+`:state/pending-payment → :state/preauthorized` transition (via
+`transition/confirm-payment`, customer-actor, `stripe-confirm-payment-intent`)
+is the natural fire point: at that moment the card has been
+authorized but not yet captured, exactly the state in which the
+lender should be asked to accept.
+
+**Why polling, not in-handler dispatch.** First attempt added the
+helper call to `transition-privileged.js` in the confirm-payment
+branch; got vetoed before commit. Both web and mobile clients fire
+`transition/confirm-payment` via `sdk.transactions.transition`
+directly (web `CheckoutPage.duck.js:399`; mobile
+`lib/checkout.ts:189`), and `confirm-payment` is not in
+`isPrivileged()` allowlist
+(`src/transactions/transactionProcessBooking.js:216` — only
+REQUEST_PAYMENT + REQUEST_PAYMENT_AFTER_INQUIRY). The transition
+never hits our `/api/transition-privileged` endpoint, so an in-handler
+dispatch would be a no-op. Sharetribe Flex doesn't expose webhooks
+either — the only reliable way to react to a customer-actor transition
+fired straight through the SDK is to poll the Integration API events
+endpoint. That's the established pattern in this repo
+(`sendShippingReminders.js`, `sendLenderRequestReminders.js`,
+`sendAutoCancelUnshipped.js` all do it).
+
+**The poller — `server/scripts/processConfirmPaymentEvents.js`.**
+- `sdk.events.query({ eventTypes: 'transaction/transitioned',
+  createdAtStart })` with `createdAtStart = now - 5min`. The 5-min
+  lookback creates a 3-min overlap with the prior tick (cron runs
+  every 2 min) so late or skipped ticks don't drop events.
+- In-code filter: `event.attributes.resource.attributes.lastTransition
+  === 'transition/confirm-payment'`. Sharetribe events stream emits
+  one event type for all transitions; the SDK doesn't support filtering
+  on `lastTransition` server-side, so the post-fetch filter is the
+  documented approach (per Integration SDK README).
+- For each matching event: `sdk.transactions.show({ id, include:
+  ['listing','customer','provider'] })` to get the full tx, then call
+  `sendLenderBookingRequestSMS({ tx, listing, lineItems, sdk })`.
+- Per-event try/catch — one bad event (Sharetribe 500 on `show`,
+  Twilio rate limit, etc.) doesn't kill the batch.
+- Structured logs at every level: `[confirm-payment-events] Querying
+  events stream` (entry), `Event summary` (fetched / matched counts),
+  per-event failures with `txId` + `eventId` + `message`,
+  `Run complete` summary `{ fetched, matched, attempted, succeeded,
+  failed }`. Mirrors the existing cron logging style.
+- `--dry-run` flag and `DRY_RUN=1` env honor — logs the would-dispatch
+  list without calling the helper. `--verbose` for skip-path detail.
+- Process exits 0 on success / 1 on fatal so the cron container can
+  shut down cleanly.
+
+**Idempotency lives in the helper.** `server/api-util/lender-booking-sms.js`
+now uses Redis (`getRedis()`) instead of the in-process
+`alreadySent()` cache. Key `lenderBookingSms:{txId}:sent` (7d TTL),
+set only AFTER a successful `sendSMS` call so a Twilio failure
+mid-flight doesn't lock out a retry. `alreadySent()`'s 2-min TTL
+in-memory map was useless across cron-tick processes (each tick is
+its own Node process — Map state doesn't survive). Per-tx (not
+per-tx-per-transition) granularity is intentional: a lender SMS for
+this transaction either has been sent or hasn't, regardless of which
+event observation triggered it. If Redis is unreachable, the helper
+falls through to send (warn-and-proceed pattern matching
+`sendShippingReminders.js`) — better an occasional dup than a
+permanent miss.
+
+**Refactor of the source code (initiate-privileged.js cleanup).**
+Stripped the entire SMS dispatch block (lines 264-475 in the
+pre-change file):
+- Lender SMS section (271-410) → moved to
+  `server/api-util/lender-booking-sms.js`.
+- Borrower SMS section (433-471) → deleted outright (silent no-op in
+  production; informational SMS for a user-initiated on-screen action
+  adds noise without value).
+- Wrapping `if (transition === 'transition/request-payment' &&
+  !isSpeculative && tx)` guard, surrounding try/catch, and
+  `🧪 Inside initiate-privileged — beginning SMS evaluation` marker
+  log (grep confirmed marker was only used by this block).
+- Eight imports that became unused after the strip: `getIntegrationSdk`,
+  `maskPhone`, `alreadySent`, `attempt/sent/failed` from metrics
+  (already unused at HEAD), `calculateTotalForProvider`,
+  `formatMoneyServerSide`, `shortLink`, `orderUrl`/`saleUrl`. Plus
+  the conditional `sendSMS` import block and the inline
+  `buildLenderMsg` function.
+- `server/api/transition-privileged.js` is UNTOUCHED. The first-pass
+  dispatch wired into the confirm-payment branch was reverted (it
+  would never have fired — see "why polling" above).
+
+The `server/api-util/lender-booking-sms.copy.test.js` regression test
+was renamed from `server/api/initiate-privileged.copy.test.js`
+(matches the helper's new home). Same regex assertions, just an
+updated `path.resolve(__dirname, …)` target.
+
+**User-side action required.** The Render cron job must be created
+manually in the Render UI to match the new `render.yaml` block —
+this project does NOT auto-sync `render.yaml` to Render (per the
+existing comments on `auto-cancel-unshipped`, `lender-request-reminders`,
+`shipping-reminders`). Create job:
+- Name: `confirm-payment-events`
+- Type: Cron Job
+- Schedule: `*/2 * * * *`
+- Build: `yarn install && yarn run render-build`
+- Start: `node server/scripts/processConfirmPaymentEvents.js --once`
+- Env: same `INTEGRATION_CLIENT_ID/SECRET`, Twilio creds, `REDIS_URL`
+  as the other lender-side crons. SendGrid not needed.
+
+**Latency expectation.** Borrower confirms payment → up to ~2 min
+until lender SMS (cron interval). Acceptable for booking flow:
+lender has a 24h window to accept after preauthorized, so a 2-min
+notification delay is invisible in practice. Compare to the previous
+in-handler dispatch which was sub-second — the latency increase is
+the cost of moving the trigger to the right state.
+
+**Soak window plan (24h, mirrors PR #58 pattern).** Watch for:
+- Render cron logs for `confirm-payment-events` show non-zero
+  `matched` counts during normal traffic windows; zero `failed`.
+- Twilio outbound volume on tag `booking_request_to_lender_alt`
+  matches the rate of completed bookings (PaymentIntent status
+  `requires_capture` from Stripe, NOT just `requires_confirmation`).
+  Pre-change baseline included abandoned-PaymentSheet noise; new
+  baseline should be lower-and-cleaner.
+- No new Sharetribe API rate-limit errors in Render logs — the new
+  cron adds ~30 events.query calls/hour, well under the limit.
+- "Lender didn't get SMS for a real booking" complaints in the
+  operator inbox or dogfood Slack channel.
+After 24h with no incidents, mark soak-complete in the next session
+entry. If `matched` count stays at 0 across normal-traffic windows,
+re-check the Render cron is actually scheduled and that
+`INTEGRATION_CLIENT_ID/SECRET` are wired in the cron's env.
+
+**Files touched.**
+- New: [server/api-util/lender-booking-sms.js](server/api-util/lender-booking-sms.js)
+  (Redis-backed dedup, helper signature
+  `sendLenderBookingRequestSMS({ tx, listing, lineItems, sdk })`)
+- New: [server/scripts/processConfirmPaymentEvents.js](server/scripts/processConfirmPaymentEvents.js)
+  (cron poller — entry point + module export)
+- New: [server/scripts/processConfirmPaymentEvents.test.js](server/scripts/processConfirmPaymentEvents.test.js)
+  (6 unit tests: filter behavior, helper invocation, error
+  isolation, missing-id skip, lookback-window math)
+- Renamed: `server/api/initiate-privileged.copy.test.js` →
+  [server/api-util/lender-booking-sms.copy.test.js](server/api-util/lender-booking-sms.copy.test.js)
+  (path constant updated; test bodies unchanged)
+- Edit: [server/api/initiate-privileged.js](server/api/initiate-privileged.js)
+  — strip SMS block + 8 imports + sendSMS marker log; add
+  in-context comment pointing at the helper + cron
+- Edit: [render.yaml](render.yaml) — new `confirm-payment-events`
+  cron block (documentation-only; not auto-synced — see User-side
+  action required above)
+
+**Verification.**
+- `grep -rn "booking_request_to_lender_alt" server/ | grep -v test |
+  grep -v node_modules` → exactly one match
+  (`server/api-util/lender-booking-sms.js`).
+- `grep -rn "booking_confirmation_to_borrower" server/ | grep -v
+  test | grep -v node_modules` → zero matches.
+- `npm run test-server` — touched tests pass; pre-existing
+  `server/__tests__/shipping-estimates.test.js` failures (4)
+  reference unexported `buildShippingLine`/`getZips` and fail
+  identically on HEAD, unrelated to this PR.
+- New poller tests: 6/6 pass via
+  `npx jest server/scripts/processConfirmPaymentEvents.test.js`.
+- Prettier baseline on `initiate-privileged.js` is non-conformant on
+  HEAD (whole-codebase drift) — this PR doesn't introduce new
+  prettier failures.
+
 ### May 7, 2026 — 4-issue SMS / inbox-copy fix-up (default-booking expire flows)
 
 **The bugs.** Three back-to-back transactions (`69f8e5ee-…`,

--- a/render.yaml
+++ b/render.yaml
@@ -119,3 +119,33 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
+
+  # Confirm-payment events poller — fires the lender booking-request SMS
+  # (1-SMS / `booking_request_to_lender_alt` tag) once a borrower's Stripe
+  # PaymentIntent is authorized (`:state/preauthorized`, transition
+  # `transition/confirm-payment`). Replaces the in-handler dispatch that
+  # used to live in initiate-privileged.js (May 8, 2026 — was firing on
+  # `request-payment` and spamming lenders for abandoned PaymentSheet
+  # sessions that died at the 15-min `payment-expired` timeout).
+  # NOTE: same as the other crons — render.yaml is NOT auto-synced in this
+  # project; service must be created manually in the Render UI to match
+  # this block. Live config target:
+  #   schedule: every 2 min (*/2 * * * *)
+  #   command: --once (process exits after each tick)
+  # 5-min lookback window (3-min overlap with prior tick); helper-side
+  # Redis dedup `lenderBookingSms:{txId}:sent` (7d TTL) suppresses
+  # duplicates from window overlap or worker restarts.
+  # Integration SDK credentials (INTEGRATION_CLIENT_ID/SECRET) and Twilio
+  # credentials must be present in the Render env. SendGrid keys are NOT
+  # needed (this cron sends SMS only, no email).
+  - type: cron
+    name: confirm-payment-events
+    env: node
+    plan: starter
+    schedule: "*/2 * * * *"
+    buildCommand: yarn install && yarn run render-build
+    startCommand: node server/scripts/processConfirmPaymentEvents.js --once
+    nodeVersion: 20.10.0
+    envVars:
+      - key: NODE_ENV
+        value: production

--- a/server/api-util/lender-booking-sms.copy.test.js
+++ b/server/api-util/lender-booking-sms.copy.test.js
@@ -1,15 +1,18 @@
 /**
- * PR-4 (10.0): initiate-privileged 1-SMS copy update.
+ * PR-4 (10.0): lender booking-request 1-SMS copy regression.
  *
- * Source-level regression: confirms the operator-approved copy change
- * landed correctly — comma (not period) after the listing title,
- * and the 24h window language replaces the old "Tap to review & accept".
+ * Source-level regression: confirms the operator-approved copy stays
+ * intact — comma (not period) after the listing title, and the 24h
+ * window language replaces the old "Tap to review & accept".
+ *
+ * Helper was extracted from initiate-privileged.js on May 8, 2026 when
+ * lender SMS moved from request-payment to confirm-payment dispatch.
  */
 
 const fs = require('fs');
 const path = require('path');
 
-const SCRIPT = path.resolve(__dirname, 'initiate-privileged.js');
+const SCRIPT = path.resolve(__dirname, 'lender-booking-sms.js');
 const src = fs.readFileSync(SCRIPT, 'utf8');
 
 describe('PR-4: 1-SMS copy', () => {

--- a/server/api-util/lender-booking-sms.js
+++ b/server/api-util/lender-booking-sms.js
@@ -1,0 +1,223 @@
+// Lender booking-request SMS dispatch.
+//
+// Extracted from server/api/initiate-privileged.js (May 8, 2026 dogfood):
+// previously fired on transition/request-payment (pending-payment), which
+// notified lenders the moment a borrower tapped Pay — even if the Stripe
+// PaymentSheet was abandoned and the tx died at payment-expired (15min).
+// Now invoked from server/scripts/processConfirmPaymentEvents.js, a cron
+// poller that watches the Sharetribe Integration API events stream for
+// transition/confirm-payment (preauthorized state). Sharetribe Flex has no
+// webhooks; polling is the established repo pattern (see
+// sendShippingReminders.js / sendLenderRequestReminders.js).
+//
+// Idempotency: the cron runs every 2 min with a 5-min overlap window, so
+// any given transaction's confirm-payment event is observed multiple
+// times. Redis key `lenderBookingSms:{txId}:sent` (7d TTL) is set only
+// after a successful Twilio dispatch, so duplicates from window overlap
+// or worker restarts are suppressed at the per-transaction granularity.
+
+const { getIntegrationSdk } = require('./integrationSdk');
+const { maskPhone } = require('./phone');
+const { calculateTotalForProvider } = require('./lineItemHelpers');
+const { formatMoneyServerSide } = require('./lenderEarnings');
+const { shortLink } = require('./shortlink');
+const { saleUrl } = require('../util/url');
+const { getRedis } = require('../redis');
+
+const SENT_TTL_SEC = 7 * 24 * 60 * 60;
+const redisSentKey = txId => `lenderBookingSms:${txId}:sent`;
+
+let sendSMS = null;
+try {
+  const smsModule = require('./sendSMS');
+  sendSMS = smsModule.sendSMS;
+} catch (error) {
+  console.warn('⚠️ SMS module not available — SMS functionality disabled');
+  sendSMS = () => Promise.resolve();
+}
+
+// 10.0 PR-4: operator-approved copy surfaces the 24h acceptance window at
+// first contact, matching the v5 process.edn expire clause. Note the
+// comma (not period) after the title — technical comma-splice but the
+// approved template (April 23, 2026).
+//
+// Example final composed message:
+//   Sherbrt 🍧: Monica wants to borrow your "Faille Halter Mini Dress",
+//   You'll earn $48 💸🤑. You have 24hrs to accept: https://sherbrt.com/r/abc
+async function buildLenderMsg(listingTitle, borrowerFirstName, payoutTotal, shortUrl) {
+  const firstName = borrowerFirstName || 'Someone';
+  const title = listingTitle || 'your listing';
+  const formattedPayout = payoutTotal ? formatMoneyServerSide(payoutTotal) : null;
+
+  let message = `Sherbrt 🍧: ${firstName} wants to borrow your "${title}"`;
+  if (formattedPayout) {
+    message += `, You'll earn ${formattedPayout} 💸🤑`;
+  }
+  message += `. You have 24hrs to accept: ${shortUrl}`;
+  return message;
+}
+
+async function sendLenderBookingRequestSMS({ tx, listing, lineItems, sdk }) {
+  console.log('📨 [SMS][booking-request] Preparing to send lender notification SMS');
+
+  const txProviderId = tx?.relationships?.provider?.data?.id || null;
+  const listingAuthorId = listing?.relationships?.author?.data?.id || null;
+  const providerId = txProviderId || listingAuthorId;
+
+  console.log('[SMS][booking-request] Provider ID resolution:', {
+    txProviderId: txProviderId?.uuid || txProviderId,
+    listingAuthorId: listingAuthorId?.uuid || listingAuthorId,
+    chosenProviderId: providerId?.uuid || providerId,
+  });
+
+  if (!providerId) {
+    console.warn('[SMS][booking-request] No provider ID from tx/listing; skipping lender SMS');
+    return;
+  }
+
+  const iSdk = getIntegrationSdk();
+  const idStr = providerId?.uuid ?? providerId;
+  const prov = await iSdk.users.show({ id: idStr });
+  const prof = prov?.data?.data?.attributes?.profile || null;
+
+  console.log('[SMS][booking-request] Provider profile fields present:', {
+    hasProtected: !!prof?.protectedData,
+    hasPublic: !!prof?.publicData,
+  });
+
+  const provPhone =
+    prof?.protectedData?.phone ??
+    prof?.protectedData?.phoneNumber ??
+    prof?.publicData?.phone ??
+    prof?.publicData?.phoneNumber ??
+    null;
+
+  console.log('[SMS][booking-request] Provider phone (raw, masked):', maskPhone(provPhone));
+
+  const borrowerId = tx?.relationships?.customer?.data?.id || null;
+  if (borrowerId && (borrowerId?.uuid ?? borrowerId) === (providerId?.uuid ?? providerId)) {
+    console.warn('[SMS][booking-request] Provider equals customer; aborting lender SMS');
+    return;
+  }
+  if (!provPhone) {
+    console.warn('[SMS][booking-request] Provider missing phone; skipping lender SMS');
+    return;
+  }
+
+  let borrowerFirstName = null;
+  if (borrowerId) {
+    try {
+      borrowerFirstName =
+        tx?.relationships?.customer?.data?.attributes?.profile?.firstName ||
+        tx?.relationships?.customer?.data?.attributes?.profile?.publicData?.firstName ||
+        tx?.relationships?.customer?.data?.attributes?.profile?.protectedData?.firstName ||
+        null;
+
+      if (!borrowerFirstName) {
+        const customer = await sdk.users.show({ id: borrowerId, include: ['profile'] });
+        const customerProf = customer?.data?.data?.attributes?.profile;
+        borrowerFirstName =
+          customerProf?.firstName ||
+          customerProf?.publicData?.firstName ||
+          customerProf?.protectedData?.firstName ||
+          null;
+      }
+    } catch (customerErr) {
+      console.warn(
+        '[SMS][booking-request] Could not fetch borrower profile for first name:',
+        customerErr.message
+      );
+    }
+  }
+
+  if (!borrowerFirstName) {
+    const txPD = tx?.attributes?.protectedData || {};
+    const rawName = txPD?.customerName || null;
+    if (typeof rawName === 'string' && rawName.trim()) {
+      borrowerFirstName = rawName.trim().split(/\s+/)[0];
+      console.log(
+        '[SMS][booking-request] Extracted first name from customerName:',
+        borrowerFirstName
+      );
+    }
+  }
+
+  let payoutTotal = null;
+  try {
+    const effectiveLineItems =
+      Array.isArray(lineItems) && lineItems.length > 0 ? lineItems : tx?.attributes?.lineItems;
+    if (effectiveLineItems && effectiveLineItems.length > 0) {
+      payoutTotal = calculateTotalForProvider(effectiveLineItems);
+      console.log('[SMS][booking-request] Calculated payout total:', payoutTotal);
+    }
+  } catch (payoutErr) {
+    console.warn('[SMS][booking-request] Could not calculate payout:', payoutErr.message);
+  }
+
+  const txId = tx?.id?.uuid || tx?.id;
+  const targetPath = `/sale/${txId}`;
+  const fullSaleUrl = txId
+    ? saleUrl(txId)
+    : process.env.WEB_APP_URL || process.env.ROOT_URL || 'https://www.sherbrt.com';
+  let shortUrl = fullSaleUrl;
+  try {
+    shortUrl = await shortLink(fullSaleUrl);
+  } catch (shortLinkErr) {
+    console.warn(
+      '[SMS][booking-request] Could not generate short link, using full URL:',
+      shortLinkErr.message
+    );
+  }
+
+  console.log(
+    '[SMS][booking-request][DEBUG] Lender link target:',
+    targetPath,
+    'shortUrl:',
+    shortUrl
+  );
+
+  const listingTitle = listing?.attributes?.title || 'your listing';
+  const formattedPayout = payoutTotal ? formatMoneyServerSide(payoutTotal) : null;
+  console.log('[SMS][booking-request][DEBUG] SMS values:', {
+    borrowerFirstName: borrowerFirstName || 'Someone (fallback)',
+    listingTitle,
+    formattedPayout: formattedPayout || 'N/A',
+    shortUrl,
+  });
+
+  const txIdStr = tx?.id?.uuid || tx?.id;
+  if (!txIdStr) {
+    console.warn('[SMS][booking-request] Missing tx id; skipping lender SMS');
+    return;
+  }
+
+  const redis = getRedis();
+  const sentKey = redisSentKey(txIdStr);
+  try {
+    if (await redis.get(sentKey)) {
+      console.log('[SMS][booking-request] duplicate suppressed (already sent):', sentKey);
+      return;
+    }
+  } catch (redisErr) {
+    console.warn('[SMS][booking-request] Redis check failed; proceeding without dedup:', redisErr.message);
+  }
+
+  try {
+    const lenderMsg = await buildLenderMsg(listingTitle, borrowerFirstName, payoutTotal, shortUrl);
+    await sendSMS(provPhone, lenderMsg, {
+      role: 'lender',
+      tag: 'booking_request_to_lender_alt',
+      meta: { listingId: listing?.id?.uuid || listing?.id },
+    });
+    console.log(`📱 [SMS][booking-request] Lender notification sent to ${maskPhone(provPhone)}`);
+    try {
+      await redis.set(sentKey, new Date().toISOString(), 'EX', SENT_TTL_SEC);
+    } catch (redisErr) {
+      console.warn('[SMS][booking-request] Failed to persist dedup key:', redisErr.message);
+    }
+  } catch (e) {
+    console.error('[SMS][booking-request] Lender SMS failed:', e.message);
+  }
+}
+
+module.exports = { sendLenderBookingRequestSMS };

--- a/server/api/initiate-privileged.js
+++ b/server/api/initiate-privileged.js
@@ -6,66 +6,18 @@ const {
   serialize,
   fetchCommission,
 } = require('../api-util/sdk');
-const { getIntegrationSdk } = require('../api-util/integrationSdk');
-const { maskPhone } = require('../api-util/phone');
-const { alreadySent } = require('../api-util/idempotency');
-const { attempt, sent, failed } = require('../api-util/metrics');
 const { normalizePhoneE164 } = require('../util/phone');
-const { calculateTotalForProvider } = require('../api-util/lineItemHelpers');
-const { formatMoneyServerSide } = require('../api-util/lenderEarnings');
-const { shortLink } = require('../api-util/shortlink');
-const { orderUrl, saleUrl } = require('../util/url');
 // Helper to normalize listingId to string
 const toUuidString = id =>
   typeof id === 'string' ? id : (id && (id.uuid || id.id)) || null;
 
-// Conditional import of sendSMS to prevent module loading errors
-let sendSMS = null;
-try {
-  const smsModule = require('../api-util/sendSMS');
-  sendSMS = smsModule.sendSMS;
-} catch (error) {
-  console.warn('⚠️ SMS module not available — SMS functionality disabled');
-  sendSMS = () => Promise.resolve(); // No-op function
-}
+// Lender SMS deferred to confirm-payment (preauthorized state) — see
+// server/api-util/lender-booking-sms.js. Avoids spamming lenders on
+// abandoned PaymentSheet sessions that die at payment-expired (15min).
+// Borrower request-confirmation SMS removed entirely: informational SMS
+// for a user-initiated on-screen action — adds noise without value.
 
 console.log('🚦 initiate-privileged endpoint is wired up');
-
-/**
- * Helper function to build lender SMS message with dynamic values
- * @param {Object} tx - Transaction object
- * @param {string} listingTitle - Listing title
- * @param {string} borrowerFirstName - Borrower's first name (optional)
- * @param {Money} payoutTotal - Lender's payout amount (Money object)
- * @param {string} shortUrl - Short URL for the transaction
- * @returns {string} SMS message
- */
-async function buildLenderMsg(tx, listingTitle, borrowerFirstName, payoutTotal, shortUrl) {
-  // Fallback values for graceful handling
-  const firstName = borrowerFirstName || 'Someone';
-  const title = listingTitle || 'your listing';
-  const formattedPayout = payoutTotal ? formatMoneyServerSide(payoutTotal) : null;
-  
-  // Build message with dynamic values.
-  //
-  // 10.0 PR-4: operator-approved copy surfaces the 24h acceptance window at
-  // first contact, matching the v5 process.edn expire clause. Note the
-  // comma (not period) after the title — technical comma-splice but the
-  // approved template (April 23, 2026).
-  //
-  // Example final composed message:
-  //   Sherbrt 🍧: Monica wants to borrow your "Faille Halter Mini Dress",
-  //   You'll earn $48 💸🤑. You have 24hrs to accept: https://sherbrt.com/r/abc
-  let message = `Sherbrt 🍧: ${firstName} wants to borrow your "${title}"`;
-
-  if (formattedPayout) {
-    message += `, You'll earn ${formattedPayout} 💸🤑`;
-  }
-
-  message += `. You have 24hrs to accept: ${shortUrl}`;
-
-  return message;
-}
 
 module.exports = (req, res) => {
   console.log('🚀 initiate-privileged endpoint HIT!');
@@ -105,10 +57,6 @@ module.exports = (req, res) => {
   
   // STEP 2: Log the transition type
   console.log('🔁 Transition received:', bodyParams?.transition);
-  
-  // STEP 3: Check that sendSMS is properly imported
-  console.log('📱 sendSMS function available:', !!sendSMS);
-  console.log('📱 sendSMS function type:', typeof sendSMS);
 
   // 🔧 FIXED: Remove unused state variables and client SDK usage
   // We'll get listing data and line items inside the trusted SDK chain
@@ -255,225 +203,6 @@ module.exports = (req, res) => {
         apiResponse = await sdk.transactions.initiate(body, queryParams);
       }
 
-      // 🔧 FIXED: Use fresh transaction data from the API response
-      const tx = apiResponse?.data?.data;  // Flex SDK shape
-      
-      // STEP 4: Add a forced test log
-      console.log('🧪 Inside initiate-privileged — beginning SMS evaluation');
-      
-      // 🔧 FIXED: Lender notification SMS for booking requests - ensure provider phone only
-      if (
-        bodyParams?.transition === 'transition/request-payment' &&
-        !isSpeculative &&
-        tx
-      ) {
-        try {
-          console.log('📨 [SMS][booking-request] Preparing to send lender notification SMS');
-          
-          // Provider resolution (you already have this pattern)
-          const txProviderId = tx?.relationships?.provider?.data?.id || null;
-          const listingAuthorId = listing?.relationships?.author?.data?.id || null;
-          const providerId = txProviderId || listingAuthorId;
-
-          console.log('[SMS][booking-request] Provider ID resolution:', {
-            txProviderId: txProviderId?.uuid || txProviderId,
-            listingAuthorId: listingAuthorId?.uuid || listingAuthorId,
-            chosenProviderId: providerId?.uuid || providerId,
-          });
-
-          if (!providerId) {
-            console.warn('[SMS][booking-request] No provider ID from tx/listing; skipping lender SMS');
-          } else {
-            // 🔑 Integration fetch (operator permissions) — can read profile.protectedData
-            const iSdk = getIntegrationSdk();
-            const idStr = providerId?.uuid ?? providerId; // Integration SDK expects a string UUID
-            const prov = await iSdk.users.show({ id: idStr });
-            const prof = prov?.data?.data?.attributes?.profile || null;
-
-            // Inspect what we got (avoid logging full PII)
-            console.log('[SMS][booking-request] Provider profile fields present:', {
-              hasProtected: !!prof?.protectedData,
-              hasPublic: !!prof?.publicData,
-            });
-
-            const provPhone =
-              prof?.protectedData?.phone ??
-              prof?.protectedData?.phoneNumber ??
-              prof?.publicData?.phone ??
-              prof?.publicData?.phoneNumber ??
-              null;
-
-            console.log('[SMS][booking-request] Provider phone (raw, masked):',
-              maskPhone(provPhone)
-            );
-
-            // Optional: safety — don't accidentally send to borrower's phone
-            const borrowerId = tx?.relationships?.customer?.data?.id || null;
-            if (borrowerId && (borrowerId?.uuid ?? borrowerId) === (providerId?.uuid ?? providerId)) {
-              console.warn('[SMS][booking-request] Provider equals customer; aborting lender SMS');
-            } else if (provPhone) {
-              // Fetch borrower profile to get first name
-              let borrowerFirstName = null;
-              if (borrowerId) {
-                try {
-                  // First, try to get firstName from transaction if customer data is already included
-                  borrowerFirstName = tx?.relationships?.customer?.data?.attributes?.profile?.firstName ||
-                                     tx?.relationships?.customer?.data?.attributes?.profile?.publicData?.firstName ||
-                                     tx?.relationships?.customer?.data?.attributes?.profile?.protectedData?.firstName ||
-                                     null;
-                  
-                  // If not found in transaction, fetch customer profile
-                  if (!borrowerFirstName) {
-                    const customer = await sdk.users.show({ 
-                      id: borrowerId,
-                      include: ['profile']
-                    });
-                    const customerProf = customer?.data?.data?.attributes?.profile;
-                    borrowerFirstName = customerProf?.firstName || 
-                                       customerProf?.publicData?.firstName ||
-                                       customerProf?.protectedData?.firstName ||
-                                       null;
-                  }
-                } catch (customerErr) {
-                  console.warn('[SMS][booking-request] Could not fetch borrower profile for first name:', customerErr.message);
-                }
-              }
-              
-              // Fallback: Extract first name from protectedData.customerName if profile lookup didn't find it
-              if (!borrowerFirstName) {
-                const rawName =
-                  finalProtectedData?.customerName ||
-                  protectedData?.customerName ||
-                  orderData?.customerName ||
-                  null;
-                
-                if (typeof rawName === 'string' && rawName.trim()) {
-                  borrowerFirstName = rawName.trim().split(/\s+/)[0];
-                  console.log('[SMS][booking-request] Extracted first name from customerName:', borrowerFirstName);
-                }
-              }
-              
-              // Calculate lender payout from line items
-              let payoutTotal = null;
-              try {
-                if (lineItems && lineItems.length > 0) {
-                  payoutTotal = calculateTotalForProvider(lineItems);
-                  console.log('[SMS][booking-request] Calculated payout total:', payoutTotal);
-                }
-              } catch (payoutErr) {
-                console.warn('[SMS][booking-request] Could not calculate payout:', payoutErr.message);
-              }
-              
-              // Generate short URL for the transaction (lender sees /sale/:id, not /order/:id)
-              const txId = tx?.id?.uuid || tx?.id;
-              const targetPath = `/sale/${txId}`;
-              const fullSaleUrl = txId ? saleUrl(txId) : (process.env.WEB_APP_URL || process.env.ROOT_URL || 'https://www.sherbrt.com');
-              let shortUrl = fullSaleUrl;
-              try {
-                shortUrl = await shortLink(fullSaleUrl);
-              } catch (shortLinkErr) {
-                console.warn('[SMS][booking-request] Could not generate short link, using full URL:', shortLinkErr.message);
-              }
-              
-              console.log('[SMS][booking-request][DEBUG] Lender link target:', targetPath, 'shortUrl:', shortUrl);
-              
-              const listingTitle = listing?.attributes?.title || 'your listing';
-              
-              // TODO: Remove this debug log after verifying borrowerFirstName works correctly
-              const formattedPayout = payoutTotal ? formatMoneyServerSide(payoutTotal) : null;
-              console.log('[SMS][booking-request][DEBUG] SMS values:', {
-                borrowerFirstName: borrowerFirstName || 'Someone (fallback)',
-                listingTitle,
-                formattedPayout: formattedPayout || 'N/A',
-                shortUrl
-              });
-              
-              const key = `${tx?.id?.uuid || 'no-tx'}:transition/request-payment:lender`;
-              if (alreadySent(key)) {
-                console.log('[SMS] duplicate suppressed (lender):', key);
-              } else {
-                try {
-                  const lenderMsg = await buildLenderMsg(tx, listingTitle, borrowerFirstName, payoutTotal, shortUrl);
-                  await sendSMS(provPhone, lenderMsg, { 
-                    role: 'lender',
-                    tag: 'booking_request_to_lender_alt',
-                    meta: { listingId: listing?.id?.uuid || listing?.id }
-                  });
-                  console.log(`📱 [SMS][booking-request] Lender notification sent to ${maskPhone(provPhone)}`);
-                } catch (e) {
-                  console.error('[SMS][booking-request] Lender SMS failed:', e.message);
-                }
-              }
-            } else {
-              console.warn('[SMS][booking-request] Provider missing phone; skipping lender SMS');
-            }
-          }
-
-          // 🔧 FIXED: Fetch customer profile if available (borrower SMS - unchanged)
-          let borrowerPhone = null;
-          const customerId = tx?.relationships?.customer?.data?.id;
-          if (customerId) {
-            try {
-              const customer = await sdk.users.show({ 
-                id: customerId,
-                include: ['profile']
-              });
-              
-              const customerProf = customer?.data?.data?.attributes?.profile;
-              borrowerPhone = customerProf?.protectedData?.phone
-                ?? customerProf?.protectedData?.phoneNumber
-                ?? customerProf?.publicData?.phone
-                ?? customerProf?.publicData?.phoneNumber
-                ?? null;
-            } catch (customerErr) {
-              console.warn('[SMS][booking-request] Could not fetch customer profile:', customerErr.message);
-            }
-          }
-
-          // Send customer confirmation SMS
-          if (customerId && borrowerPhone) {
-            try {
-              console.log('📨 [SMS][customer-confirmation] Preparing to send customer confirmation SMS');
-              
-                              const listingTitle = listing?.attributes?.title || 'your listing';
-                // Carrier-friendly borrower message - use order URL for borrower
-                const txIdForBorrower = tx?.id?.uuid || tx?.id;
-                const fullOrderUrl = txIdForBorrower ? orderUrl(txIdForBorrower) : (process.env.WEB_APP_URL || process.env.ROOT_URL || 'https://www.sherbrt.com');
-                let borrowerLink = fullOrderUrl;
-                try {
-                  borrowerLink = await shortLink(fullOrderUrl);
-                } catch (shortLinkErr) {
-                  console.warn('[SMS][customer-confirmation] Could not generate short link, using full URL:', shortLinkErr.message);
-                }
-                const borrowerMsg = `Sherbrt: your booking request for "${listingTitle}" was sent. Track: ${borrowerLink}`;
-              
-              const key = `${tx?.id?.uuid || 'no-tx'}:transition/request-payment:borrower`;
-              if (alreadySent(key)) {
-                console.log('[SMS] duplicate suppressed (borrower):', key);
-              } else {
-                try {
-                  await sendSMS(borrowerPhone, borrowerMsg, { 
-                    role: 'borrower',
-                    tag: 'booking_confirmation_to_borrower',
-                    meta: { listingId: listing?.id?.uuid || listing?.id }
-                  });
-                  console.log(`✅ [SMS][customer-confirmation] Customer confirmation sent to ${maskPhone(borrowerPhone)}`);
-                } catch (e) {
-                  console.error('[SMS][customer-confirmation] Customer SMS failed:', e.message);
-                }
-              }
-              
-            } catch (customerSmsErr) {
-              console.error('[SMS][customer-confirmation] Customer SMS failed:', customerSmsErr.message);
-            }
-          } else {
-            console.log('[SMS][customer-confirmation] Skipping customer SMS - missing customerId or phone:', { customerId, borrowerPhone });
-          }
-        } catch (err) {
-          console.error('❌ [SMS][booking-request] Error in SMS logic:', err.message);
-        }
-      }
-      
       // 🔧 FIXED: Return the API response to be handled by the final .then()
       return apiResponse;
     })

--- a/server/scripts/processConfirmPaymentEvents.js
+++ b/server/scripts/processConfirmPaymentEvents.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Confirm-Payment Events Poller
+ *
+ * Polls the Sharetribe Integration API events stream for
+ * `transaction/transitioned` events whose resource has
+ * `lastTransition === 'transition/confirm-payment'`, then dispatches the
+ * lender booking-request SMS. Replaces the in-handler dispatch we used to
+ * run from initiate-privileged.js — that fired on request-payment
+ * (pending-payment) and spammed lenders for abandoned PaymentSheet
+ * sessions that died at the 15-min payment-expired timeout.
+ *
+ * WHY POLLING. Sharetribe Flex doesn't expose webhooks; polling the
+ * Integration API events endpoint is the established pattern in this repo
+ * (mirrors sendShippingReminders.js / sendLenderRequestReminders.js /
+ * sendAutoCancelUnshipped.js). Both web and mobile clients fire
+ * transition/confirm-payment via sdk.transactions.transition directly
+ * (not through /api/transition-privileged), so the server endpoint never
+ * sees the transition.
+ *
+ * CRON. Every 2 minutes (`*\/2 * * * *`) with a 5-minute lookback window.
+ * The 3-minute overlap is intentional: late events still get picked up if
+ * a tick is delayed or skipped, and the helper's Redis dedup
+ * (`lenderBookingSms:{txId}:sent`, 7d TTL) prevents duplicate SMS from
+ * the overlap.
+ *
+ * LATENCY. Borrower confirms payment → up to ~2 min until lender SMS.
+ * Acceptable for booking flow (lender has a 24h window to accept).
+ */
+require('dotenv').config();
+
+const getFlexSdk = require('../util/getFlexSdk');
+const { sendLenderBookingRequestSMS } = require('../api-util/lender-booking-sms');
+
+const argv = process.argv.slice(2);
+const has = flag => argv.includes(flag);
+const VERBOSE = has('--verbose') || process.env.VERBOSE === '1';
+const DRY = has('--dry-run') || process.env.DRY_RUN === '1';
+
+const LOOKBACK_MS = 5 * 60 * 1000;
+const TARGET_TRANSITION = 'transition/confirm-payment';
+
+async function processConfirmPaymentEvents({ sdk } = {}) {
+  const flexSdk = sdk || getFlexSdk();
+
+  const now = new Date();
+  const createdAtStart = new Date(now.getTime() - LOOKBACK_MS).toISOString();
+
+  console.log('[confirm-payment-events] Querying events stream', {
+    eventTypes: 'transaction/transitioned',
+    createdAtStart,
+    lookbackMs: LOOKBACK_MS,
+    dryRun: DRY,
+  });
+
+  let events;
+  try {
+    const resp = await flexSdk.events.query({
+      eventTypes: 'transaction/transitioned',
+      createdAtStart,
+    });
+    events = resp?.data?.data || [];
+  } catch (queryErr) {
+    console.error('[confirm-payment-events] events.query failed', {
+      status: queryErr.response && queryErr.response.status,
+      message: queryErr.message,
+    });
+    throw queryErr;
+  }
+
+  const matching = events.filter(
+    ev => ev?.attributes?.resource?.attributes?.lastTransition === TARGET_TRANSITION
+  );
+
+  console.log('[confirm-payment-events] Event summary', {
+    fetched: events.length,
+    matched: matching.length,
+    target: TARGET_TRANSITION,
+  });
+
+  let attempted = 0;
+  let succeeded = 0;
+  let failed = 0;
+
+  for (const ev of matching) {
+    const txId = ev?.attributes?.resource?.id?.uuid || ev?.attributes?.resource?.id;
+    if (!txId) {
+      if (VERBOSE) {
+        console.warn('[confirm-payment-events] Event missing resource id; skipping', { eventId: ev?.id });
+      }
+      continue;
+    }
+
+    attempted++;
+
+    try {
+      const showResp = await flexSdk.transactions.show({
+        id: txId,
+        include: ['listing', 'customer', 'provider'],
+      });
+      const tx = showResp?.data?.data;
+      const included = showResp?.data?.included || [];
+      const listing = included.find(r => r.type === 'listing') || null;
+      const lineItems = tx?.attributes?.lineItems || null;
+
+      if (!tx) {
+        console.warn('[confirm-payment-events] Transaction not found; skipping', { txId });
+        failed++;
+        continue;
+      }
+
+      if (DRY) {
+        console.log('[confirm-payment-events] DRY-RUN: would dispatch lender SMS', {
+          txId,
+          listingId: listing?.id?.uuid || listing?.id,
+        });
+        continue;
+      }
+
+      await sendLenderBookingRequestSMS({ tx, listing, lineItems, sdk: flexSdk });
+      succeeded++;
+    } catch (err) {
+      failed++;
+      console.error('[confirm-payment-events] Per-event failure (isolated)', {
+        txId,
+        eventId: ev?.id?.uuid || ev?.id,
+        message: err.message,
+      });
+    }
+  }
+
+  console.log('[confirm-payment-events] Run complete', {
+    fetched: events.length,
+    matched: matching.length,
+    attempted,
+    succeeded,
+    failed,
+  });
+
+  return { fetched: events.length, matched: matching.length, attempted, succeeded, failed };
+}
+
+if (require.main === module) {
+  processConfirmPaymentEvents()
+    .then(() => {
+      console.log('[confirm-payment-events] Script completed successfully');
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error('[confirm-payment-events] Fatal:', err.message);
+      process.exit(1);
+    });
+}
+
+module.exports = { processConfirmPaymentEvents };

--- a/server/scripts/processConfirmPaymentEvents.test.js
+++ b/server/scripts/processConfirmPaymentEvents.test.js
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for the confirm-payment events poller.
+ *
+ * Replaces the in-handler dispatch we used to run from initiate-privileged.js.
+ * Coverage:
+ *   - filters events stream for `lastTransition === 'transition/confirm-payment'`
+ *   - skips events for unrelated transitions (request-payment, accept, etc.)
+ *   - invokes helper with { tx, listing, lineItems, sdk } shape
+ *   - per-event try/catch isolates failures (one bad event doesn't kill the batch)
+ *   - exits cleanly with a result summary
+ */
+
+jest.mock('../api-util/lender-booking-sms', () => ({
+  sendLenderBookingRequestSMS: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../util/getFlexSdk', () => jest.fn());
+
+const { sendLenderBookingRequestSMS } = require('../api-util/lender-booking-sms');
+const { processConfirmPaymentEvents } = require('./processConfirmPaymentEvents');
+
+function makeEvent({ txId, lastTransition }) {
+  return {
+    id: { uuid: `evt-${txId}` },
+    attributes: {
+      eventType: 'transaction/transitioned',
+      resource: {
+        id: { uuid: txId },
+        type: 'transaction',
+        attributes: { lastTransition },
+      },
+    },
+  };
+}
+
+function makeShowResp(txId, { listingId = `lst-${txId}`, lineItems = [{ code: 'line-item/day' }] } = {}) {
+  return {
+    data: {
+      data: {
+        id: { uuid: txId },
+        type: 'transaction',
+        attributes: { lineItems },
+        relationships: {},
+      },
+      included: [{ id: { uuid: listingId }, type: 'listing', attributes: { title: 'Test' } }],
+    },
+  };
+}
+
+function makeSdk({ events, showByTxId = {}, showFailures = {} }) {
+  return {
+    events: {
+      query: jest.fn().mockResolvedValue({ data: { data: events } }),
+    },
+    transactions: {
+      show: jest.fn().mockImplementation(({ id }) => {
+        if (showFailures[id]) return Promise.reject(showFailures[id]);
+        if (showByTxId[id]) return Promise.resolve(showByTxId[id]);
+        return Promise.resolve(makeShowResp(id));
+      }),
+    },
+  };
+}
+
+describe('processConfirmPaymentEvents', () => {
+  beforeEach(() => {
+    sendLenderBookingRequestSMS.mockClear();
+    sendLenderBookingRequestSMS.mockResolvedValue(undefined);
+  });
+
+  test('filters out events whose lastTransition is NOT confirm-payment', async () => {
+    const events = [
+      makeEvent({ txId: 'tx-A', lastTransition: 'transition/request-payment' }),
+      makeEvent({ txId: 'tx-B', lastTransition: 'transition/accept' }),
+      makeEvent({ txId: 'tx-C', lastTransition: 'transition/decline' }),
+    ];
+    const sdk = makeSdk({ events });
+
+    const result = await processConfirmPaymentEvents({ sdk });
+
+    expect(sdk.events.query).toHaveBeenCalledWith(
+      expect.objectContaining({ eventTypes: 'transaction/transitioned' })
+    );
+    expect(sdk.transactions.show).not.toHaveBeenCalled();
+    expect(sendLenderBookingRequestSMS).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ fetched: 3, matched: 0, attempted: 0, succeeded: 0, failed: 0 });
+  });
+
+  test('dispatches lender SMS for each confirm-payment event', async () => {
+    const events = [
+      makeEvent({ txId: 'tx-1', lastTransition: 'transition/confirm-payment' }),
+      makeEvent({ txId: 'tx-2', lastTransition: 'transition/request-payment' }),
+      makeEvent({ txId: 'tx-3', lastTransition: 'transition/confirm-payment' }),
+    ];
+    const sdk = makeSdk({ events });
+
+    const result = await processConfirmPaymentEvents({ sdk });
+
+    expect(sdk.transactions.show).toHaveBeenCalledTimes(2);
+    expect(sendLenderBookingRequestSMS).toHaveBeenCalledTimes(2);
+    expect(sendLenderBookingRequestSMS).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tx: expect.objectContaining({ id: { uuid: 'tx-1' }, type: 'transaction' }),
+        listing: expect.objectContaining({ type: 'listing' }),
+        lineItems: expect.any(Array),
+        sdk,
+      })
+    );
+    expect(result).toMatchObject({ fetched: 3, matched: 2, attempted: 2, succeeded: 2, failed: 0 });
+  });
+
+  test('per-event failure does not kill the batch', async () => {
+    const events = [
+      makeEvent({ txId: 'tx-good', lastTransition: 'transition/confirm-payment' }),
+      makeEvent({ txId: 'tx-bad', lastTransition: 'transition/confirm-payment' }),
+      makeEvent({ txId: 'tx-also-good', lastTransition: 'transition/confirm-payment' }),
+    ];
+    const sdk = makeSdk({
+      events,
+      showFailures: { 'tx-bad': new Error('Sharetribe 500') },
+    });
+
+    const result = await processConfirmPaymentEvents({ sdk });
+
+    expect(sdk.transactions.show).toHaveBeenCalledTimes(3);
+    expect(sendLenderBookingRequestSMS).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ matched: 3, attempted: 3, succeeded: 2, failed: 1 });
+  });
+
+  test('helper failure on one event does not block subsequent events (idempotency-friendly)', async () => {
+    sendLenderBookingRequestSMS
+      .mockRejectedValueOnce(new Error('twilio rate limit'))
+      .mockResolvedValueOnce(undefined);
+
+    const events = [
+      makeEvent({ txId: 'tx-fail', lastTransition: 'transition/confirm-payment' }),
+      makeEvent({ txId: 'tx-ok', lastTransition: 'transition/confirm-payment' }),
+    ];
+    const sdk = makeSdk({ events });
+
+    const result = await processConfirmPaymentEvents({ sdk });
+
+    expect(sendLenderBookingRequestSMS).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ matched: 2, attempted: 2, succeeded: 1, failed: 1 });
+  });
+
+  test('skips events whose resource id is missing', async () => {
+    const events = [
+      {
+        id: { uuid: 'evt-noid' },
+        attributes: {
+          eventType: 'transaction/transitioned',
+          resource: { attributes: { lastTransition: 'transition/confirm-payment' } },
+        },
+      },
+      makeEvent({ txId: 'tx-real', lastTransition: 'transition/confirm-payment' }),
+    ];
+    const sdk = makeSdk({ events });
+
+    const result = await processConfirmPaymentEvents({ sdk });
+
+    expect(sdk.transactions.show).toHaveBeenCalledTimes(1);
+    expect(sdk.transactions.show).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'tx-real' })
+    );
+    expect(result).toMatchObject({ matched: 2, attempted: 1 });
+  });
+
+  test('5-min lookback window is passed to events.query', async () => {
+    const sdk = makeSdk({ events: [] });
+    const before = Date.now();
+    await processConfirmPaymentEvents({ sdk });
+    const after = Date.now();
+
+    const call = sdk.events.query.mock.calls[0][0];
+    const startMs = Date.parse(call.createdAtStart);
+    expect(startMs).toBeGreaterThanOrEqual(before - 5 * 60 * 1000);
+    expect(startMs).toBeLessThanOrEqual(after - 5 * 60 * 1000 + 50);
+  });
+});


### PR DESCRIPTION
…ts poller

Lender 1-SMS was firing on transition/request-payment (pending-payment), spamming lenders for abandoned PaymentSheet sessions that died at the 15-min payment-expired timeout. Move the dispatch to fire on transition/confirm-payment (preauthorized) so lenders are only notified after Stripe has actually authorized the card.

Sharetribe Flex doesn't expose webhooks and confirm-payment is fired client-side via sdk.transactions.transition (not through our privileged endpoint), so the trigger has to be a cron poller against the Integration API events stream — the established pattern in this repo (sendShippingReminders.js / sendLenderRequestReminders.js / sendAutoCancelUnshipped.js).

- Extract dispatch logic from initiate-privileged.js into server/api-util/lender-booking-sms.js with Redis-backed dedup (lenderBookingSms:{txId}:sent, 7d TTL — survives across cron-tick processes; in-memory alreadySent() doesn't).
- New cron server/scripts/processConfirmPaymentEvents.js polls events every 2 min with a 5-min lookback; per-event try/catch isolates failures; structured run summary log.
- Remove the borrower request-confirmation SMS entirely — silent no-op in production (logs show customerId=undefined consistently) and an informational SMS for a user-initiated on-screen action adds noise without value.
- render.yaml documents the new cron block. Per existing convention in this repo, render.yaml is NOT auto-synced; the cron must be created manually in the Render UI (see CLAUDE_CONTEXT.md May 8 entry for exact config).

Latency: borrower confirms payment → up to ~2 min until lender SMS (invisible against the 24h lender accept window).

Verification:
- npm run test-server: 219/223 pass; 4 failures (shipping-estimates) pre-exist on HEAD with unexported buildShippingLine/getZips, unrelated to this PR.
- New poller tests: 6/6 pass.
- grep "booking_request_to_lender_alt" server/ → 1 match (the helper).
- grep "booking_confirmation_to_borrower" server/ → 0 matches.