### PR TITLE
fix(sms): use calculateLenderPayoutTotal for Integration SDK plain-object lineItems shape

### DIFF
--- a/CLAUDE_CONTEXT.md
+++ b/CLAUDE_CONTEXT.md
@@ -463,6 +463,57 @@ re-check the Render cron is actually scheduled and that
   HEAD (whole-codebase drift) — this PR doesn't introduce new
   prettier failures.
 
+**May 8, 2026 — addendum (lineItems shape fix, post-deploy).**
+First dogfood after PR #63 merged validated end-to-end (SMS delivered
+to lender via the cron) but surfaced a small follow-up bug in the
+Render logs:
+
+```
+[SMS][booking-request] Could not calculate payout: Value must be a Money type
+```
+
+The lender SMS shipped without the earnings tease — `"Sherbrt 🍧:
+Amalia wants to borrow your \"Cindy Dress\". You have 24hrs to
+accept: <url>"` — losing the conversion-driving `"You'll earn $XX.XX
+💸🤑"` clause. *Cause.* `tx.attributes.lineItems[i].unitPrice`
+(and `lineTotal`) come back from `sdk.transactions.show()` as plain
+`{ amount, currency }` objects, not `Money` class instances. The
+helper called `calculateTotalForProvider` from
+`server/api-util/lineItemHelpers.js`, which delegates to
+`getAmountAsDecimalJS`, which has an `instanceof Money` guard
+(`server/api-util/currency.js:215`) — that's the throw site.
+
+*Fix.* Swap to `calculateLenderPayoutTotal` from
+`server/api-util/lenderEarnings.js`. That helper was authored
+specifically for the Integration-SDK shape: it tries
+`calculateTotalForProvider` first and on throw falls back to a manual
+calculation that handles plain `{amount, currency}` objects AND
+goog.math.Long amounts, returning `null` instead of throwing. Same
+helper `sendLenderRequestReminders.js` uses for the 60m follow-up
+SMS — its docblock literally says "used by both the initial lender
+SMS and the 60-minute follow-up reminder worker so the two messages
+can never drift on the earnings amount." Should have used it during
+the original PR #63 extraction; missed it.
+
+*Files touched.*
+- Edit: `server/api-util/lender-booking-sms.js` — replace
+  `calculateTotalForProvider` import and call with
+  `calculateLenderPayoutTotal`. Drop the surrounding try/catch
+  (the new helper returns `null` instead of throwing).
+- New: `server/api-util/lender-booking-sms.payout.test.js` — 3
+  unit tests using a `tx` fixture with plain-object `lineItems`
+  (mirrors `transactions.show()` output): asserts
+  `"You'll earn $90.00 💸🤑"` is in the SMS body, fallback to
+  `tx.attributes.lineItems` when explicit `lineItems` arg is null,
+  graceful no-earnings copy when lineItems are missing entirely.
+
+*Branch.* `chore/lender-sms-payout-money-shape` (off main post-PR-63
+merge). Verification: `npm run test-server` 222/226 pass — same 4
+pre-existing `shipping-estimates.test.js` failures unchanged. Manual
+cron retest after Render redeploy: confirm log shows `[SMS][booking-
+request] Calculated payout total: Money { ... }` and SMS body
+includes earnings tease.
+
 ### May 7, 2026 — 4-issue SMS / inbox-copy fix-up (default-booking expire flows)
 
 **The bugs.** Three back-to-back transactions (`69f8e5ee-…`,

--- a/server/api-util/lender-booking-sms.js
+++ b/server/api-util/lender-booking-sms.js
@@ -18,8 +18,7 @@
 
 const { getIntegrationSdk } = require('./integrationSdk');
 const { maskPhone } = require('./phone');
-const { calculateTotalForProvider } = require('./lineItemHelpers');
-const { formatMoneyServerSide } = require('./lenderEarnings');
+const { calculateLenderPayoutTotal, formatMoneyServerSide } = require('./lenderEarnings');
 const { shortLink } = require('./shortlink');
 const { saleUrl } = require('../util/url');
 const { getRedis } = require('../redis');
@@ -142,16 +141,18 @@ async function sendLenderBookingRequestSMS({ tx, listing, lineItems, sdk }) {
     }
   }
 
-  let payoutTotal = null;
-  try {
-    const effectiveLineItems =
-      Array.isArray(lineItems) && lineItems.length > 0 ? lineItems : tx?.attributes?.lineItems;
-    if (effectiveLineItems && effectiveLineItems.length > 0) {
-      payoutTotal = calculateTotalForProvider(effectiveLineItems);
-      console.log('[SMS][booking-request] Calculated payout total:', payoutTotal);
-    }
-  } catch (payoutErr) {
-    console.warn('[SMS][booking-request] Could not calculate payout:', payoutErr.message);
+  // Money-shape note: tx.attributes.lineItems from sdk.transactions.show()
+  // (Integration SDK) come back with unitPrice/lineTotal as plain
+  // { amount, currency } objects (or goog.math.Long amounts), NOT Money
+  // instances. calculateLenderPayoutTotal handles both shapes — same helper
+  // sendLenderRequestReminders.js uses for the 60m follow-up SMS.
+  const effectiveLineItems =
+    Array.isArray(lineItems) && lineItems.length > 0 ? lineItems : tx?.attributes?.lineItems;
+  const payoutTotal = calculateLenderPayoutTotal(effectiveLineItems);
+  if (payoutTotal) {
+    console.log('[SMS][booking-request] Calculated payout total:', payoutTotal);
+  } else if (effectiveLineItems && effectiveLineItems.length > 0) {
+    console.warn('[SMS][booking-request] Could not calculate payout from lineItems');
   }
 
   const txId = tx?.id?.uuid || tx?.id;

--- a/server/api-util/lender-booking-sms.payout.test.js
+++ b/server/api-util/lender-booking-sms.payout.test.js
@@ -1,0 +1,158 @@
+/**
+ * Regression test for the May 8, 2026 dogfood bug:
+ *
+ *   [SMS][booking-request] Could not calculate payout: Value must be a Money type
+ *
+ * Cause: when the cron poller fetches the transaction via
+ * sdk.transactions.show() (Integration SDK), tx.attributes.lineItems[i]
+ * unitPrice/lineTotal come back as plain { amount, currency } objects, NOT
+ * Money instances. calculateTotalForProvider in lineItemHelpers.js does an
+ * `instanceof Money` check and throws on plain objects. The helper now uses
+ * calculateLenderPayoutTotal (server/api-util/lenderEarnings.js) which has a
+ * tolerant fallback path for the plain-object shape — same helper
+ * sendLenderRequestReminders.js uses.
+ */
+
+jest.mock('../redis', () => ({
+  getRedis: jest.fn(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK'),
+  })),
+}));
+
+jest.mock('./integrationSdk', () => ({
+  getIntegrationSdk: jest.fn(() => ({
+    users: {
+      show: jest.fn().mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              profile: { protectedData: { phone: '+15551112222' } },
+            },
+          },
+        },
+      }),
+    },
+  })),
+}));
+
+jest.mock('./shortlink', () => ({
+  shortLink: jest.fn(async url => url),
+}));
+
+jest.mock('./sendSMS', () => ({
+  sendSMS: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { sendSMS: sendSmsMock } = require('./sendSMS');
+const { sendLenderBookingRequestSMS } = require('./lender-booking-sms');
+
+// Mirrors the shape that sdk.transactions.show() returns from the
+// Integration SDK: line items where unitPrice / lineTotal are plain
+// { amount, currency } objects (not Money instances).
+function makePlainObjectLineItems() {
+  return [
+    {
+      code: 'line-item/day',
+      includeFor: ['customer', 'provider'],
+      unitPrice: { amount: 5000, currency: 'USD' }, // $50.00
+      quantity: 2,
+      lineTotal: { amount: 10000, currency: 'USD' }, // $100.00
+      reversal: false,
+    },
+    {
+      code: 'line-item/provider-commission',
+      includeFor: ['provider'],
+      unitPrice: { amount: 10000, currency: 'USD' },
+      percentage: -10,
+      lineTotal: { amount: -1000, currency: 'USD' }, // -$10.00 commission
+      reversal: false,
+    },
+    {
+      code: 'line-item/customer-commission',
+      includeFor: ['customer'],
+      unitPrice: { amount: 10000, currency: 'USD' },
+      percentage: 5,
+      lineTotal: { amount: 500, currency: 'USD' },
+      reversal: false,
+    },
+  ];
+}
+
+function makeTx() {
+  return {
+    id: { uuid: 'tx-abc-123' },
+    type: 'transaction',
+    attributes: {
+      lineItems: makePlainObjectLineItems(),
+      protectedData: {},
+    },
+    relationships: {
+      provider: { data: { id: { uuid: 'prov-1' } } },
+      customer: {
+        data: {
+          id: { uuid: 'cust-1' },
+          attributes: { profile: { firstName: 'Amalia' } },
+        },
+      },
+    },
+  };
+}
+
+function makeListing() {
+  return {
+    id: { uuid: 'list-1' },
+    type: 'listing',
+    attributes: { title: 'Cindy Dress' },
+    relationships: { author: { data: { id: { uuid: 'prov-1' } } } },
+  };
+}
+
+describe('sendLenderBookingRequestSMS — payout calculation from plain-object lineItems', () => {
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    sendSmsMock.mockResolvedValue(undefined);
+  });
+
+  test('SMS body includes "You\'ll earn $90.00" when lineItems are Integration-SDK shape', async () => {
+    const tx = makeTx();
+    const listing = makeListing();
+    const sdk = { users: { show: jest.fn() } };
+
+    await sendLenderBookingRequestSMS({ tx, listing, lineItems: tx.attributes.lineItems, sdk });
+
+    expect(sendSmsMock).toHaveBeenCalledTimes(1);
+    const [, body] = sendSmsMock.mock.calls[0];
+    // Provider portion: 100 (rental) + (-10) (commission) = $90.00
+    expect(body).toMatch(/You'll earn \$90\.00 💸🤑/);
+    expect(body).toMatch(/Amalia wants to borrow your "Cindy Dress"/);
+    expect(body).toMatch(/You have 24hrs to accept:/);
+  });
+
+  test('falls back to tx.attributes.lineItems when explicit lineItems arg is omitted', async () => {
+    const tx = makeTx();
+    const listing = makeListing();
+    const sdk = { users: { show: jest.fn() } };
+
+    await sendLenderBookingRequestSMS({ tx, listing, lineItems: null, sdk });
+
+    expect(sendSmsMock).toHaveBeenCalledTimes(1);
+    const [, body] = sendSmsMock.mock.calls[0];
+    expect(body).toMatch(/You'll earn \$90\.00 💸🤑/);
+  });
+
+  test('SMS still sends (without earnings tease) when lineItems are missing entirely', async () => {
+    const tx = makeTx();
+    tx.attributes.lineItems = [];
+    const listing = makeListing();
+    const sdk = { users: { show: jest.fn() } };
+
+    await sendLenderBookingRequestSMS({ tx, listing, lineItems: null, sdk });
+
+    expect(sendSmsMock).toHaveBeenCalledTimes(1);
+    const [, body] = sendSmsMock.mock.calls[0];
+    expect(body).toMatch(/Amalia wants to borrow your "Cindy Dress"/);
+    expect(body).toMatch(/You have 24hrs to accept:/);
+    expect(body).not.toMatch(/You'll earn/);
+  });
+});


### PR DESCRIPTION

PR #63 dogfood validated end-to-end — SMS delivered to lender via the cron — but Render logs surfaced:

  [SMS][booking-request] Could not calculate payout: Value must be a Money type

Result: SMS body shipped without the conversion-driving "You'll earn $XX.XX 💸🤑" clause.

Cause. tx.attributes.lineItems[i].unitPrice/lineTotal come back from sdk.transactions.show() (Integration SDK) as plain { amount, currency } objects, not Money instances. calculateTotalForProvider delegates to getAmountAsDecimalJS, which has an `instanceof Money` guard (server/api-util/currency.js:215) — that's the throw site.

Fix. Swap to calculateLenderPayoutTotal from
server/api-util/lenderEarnings.js. That helper was authored specifically for this shape: tries the Money path first, falls back to a manual calc that handles plain { amount, currency } objects and goog.math.Long amounts, returns null instead of throwing. Same helper sendLenderRequestReminders.js uses for the 60m follow-up SMS — its docblock says "used by both the initial lender SMS and the 60-minute follow-up reminder worker so the two messages can never drift on the earnings amount." Should have used it during the original extraction; missed it.

Verification:
- npx jest server/api-util/lender-booking-sms.payout.test.js: 3/3 pass. New regression tests use plain-object lineItems fixture mirroring the Integration SDK shape; assert SMS body contains "You'll earn $90.00", fallback to tx.attributes.lineItems works, graceful no-earnings copy when lineItems empty.
- npm run test-server: 222/226 pass; the 4 failures (shipping-estimates.test.js) pre-exist on HEAD with unexported buildShippingLine/getZips, unrelated to this PR.
- grep "calculateTotalForProvider" server/api-util/lender-booking-sms.js → 0 hits.
- grep "calculateLenderPayoutTotal" server/api-util/lender-booking-sms.js → 3 hits (import + comment + call).