### PR TITLE
Add 'Make cover photo' to listing photo editor

### DIFF
--- a/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/EditListingPhotosForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/EditListingPhotosForm.js
@@ -84,7 +84,7 @@ export const FieldAddImage = props => {
 
 // Component that shows listing images from "images" field array
 const FieldListingImage = props => {
-  const { name, intl, onRemoveImage, aspectWidth, aspectHeight, variantPrefix } = props;
+  const { name, intl, onRemoveImage, isCover, onMakeCover, aspectWidth, aspectHeight, variantPrefix } = props;
   return (
     <Field name={name}>
       {fieldProps => {
@@ -99,6 +99,10 @@ const FieldListingImage = props => {
               id: 'EditListingPhotosForm.savedImageAltText',
             })}
             onRemoveImage={() => onRemoveImage(image?.id)}
+            isCover={isCover}
+            onMakeCover={onMakeCover}
+            coverLabel={intl.formatMessage({ id: 'EditListingPhotosForm.coverLabel' })}
+            makeCoverLabel={intl.formatMessage({ id: 'EditListingPhotosForm.makeCover' })}
             aspectWidth={aspectWidth}
             aspectHeight={aspectHeight}
             variantPrefix={variantPrefix}
@@ -241,6 +245,8 @@ export const EditListingPhotosForm = props => {
                     <FieldListingImage
                       key={name}
                       name={name}
+                      isCover={index === 0}
+                      onMakeCover={() => fields.move(index, 0)}
                       onRemoveImage={imageId => {
                         fields.remove(index);
                         onRemoveImage(imageId);

--- a/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/ListingImage.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/ListingImage.js
@@ -62,6 +62,10 @@ const ListingImage = props => {
     image,
     savedImageAltText,
     onRemoveImage,
+    isCover,
+    onMakeCover,
+    coverLabel,
+    makeCoverLabel,
     aspectWidth = 1,
     aspectHeight = 1,
     variantPrefix = 'listing-card',
@@ -70,6 +74,22 @@ const ListingImage = props => {
     e.stopPropagation();
     onRemoveImage(image.id);
   };
+  const handleMakeCoverClick = e => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (onMakeCover) onMakeCover();
+  };
+  // The first image is the listing's cover (used as the card thumbnail on web
+  // and in the mobile app). Show a badge on the cover, and a "Make cover"
+  // button on the others so any image can be promoted to first WITHOUT
+  // re-uploading the rest.
+  const coverControl = isCover ? (
+    <div className={css.coverBadge}>{coverLabel || 'Cover'}</div>
+  ) : onMakeCover ? (
+    <button type="button" className={css.makeCoverButton} onClick={handleMakeCoverClick}>
+      {makeCoverLabel || 'Make cover'}
+    </button>
+  ) : null;
 
   if (image.file && !image.attributes) {
     // Add remove button only when the image has been uploaded and can be removed
@@ -132,6 +152,7 @@ const ListingImage = props => {
             />
           </AspectRatioWrapper>
           <RemoveImageButton onClick={handleRemoveClick} />
+          {coverControl}
         </div>
       </div>
     );

--- a/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/ListingImage.module.css
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/ListingImage.module.css
@@ -54,6 +54,38 @@
   border-radius: var(--borderRadius);
 }
 
+/* "Cover" badge shown on the first (cover) image. */
+.coverBadge {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 4px 8px;
+  background-color: var(--marketplaceColor);
+  color: var(--colorWhite);
+  font-size: 12px;
+  font-weight: 600;
+  border-bottom-right-radius: 2px;
+}
+
+/* "Make cover" button shown on non-cover images. */
+.makeCoverButton {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 4px 8px;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: var(--colorWhite);
+  font-size: 12px;
+  font-weight: 600;
+  border: none;
+  border-top-right-radius: 2px;
+  cursor: pointer;
+}
+
+.makeCoverButton:hover {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
 .thumbnailLoading {
   position: absolute;
   top: 0;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -366,6 +366,8 @@
   "EditListingPage.titleEditListing": "Edit listing",
   "EditListingPhotosForm.addImagesTip": "Tip: Show borrowers how good you looked in real life and upload the best 2-3 photos from different angles. We encourage you to share pics from your socials rather than try-on mirror selfies.",
   "EditListingPhotosForm.chooseImage": "+ Add a photo…",
+  "EditListingPhotosForm.coverLabel": "Cover",
+  "EditListingPhotosForm.makeCover": "Make cover",
   "EditListingPhotosForm.imageRequired": "You need to add at least one photo.",
   "EditListingPhotosForm.imageTypes": ".JPG or .PNG. Max. 20 MB",
   "EditListingPhotosForm.imageUploadFailed.uploadFailed": "Image upload failed. Please try again.",


### PR DESCRIPTION
Add "Make cover photo" to the listing photo editor
Adds the ability to set any listing photo as the cover (first image) without re-uploading the rest. The first image shows a "Cover" badge; every other image gets a "Make cover" button that moves it to the front via fields.move(index, 0). Fixes the issue where re-adding a replaced photo appended it to the end with no way to reorder. Since both the website and mobile app use the first image as the card thumbnail, this controls the cover on both.