### PR TITLE
Fix listing page to show brand option label instead of value

### DIFF
--- a/src/containers/ListingPage/ListingPageCarousel.js
+++ b/src/containers/ListingPage/ListingPageCarousel.js
@@ -258,6 +258,18 @@ const pendingIsApproved = isPendingApprovalVariant && isApproved;
 
 
 
+  // Resolve the brand's display label from the listing field config (hosted
+  // enumOptions), so we show the configured label (e.g. "AFRM") rather than a
+  // title-cased version of the stored option value (e.g. "Afrm"). Falls back to
+  // a title-cased value only if no matching option/label is configured.
+  const brandFieldConfig = config?.listing?.listingFields?.find(f => f.key === 'brand');
+  const brandOption = brandFieldConfig?.enumOptions?.find(o => `${o.option}` === publicData?.brand);
+  const brandLabel =
+    brandOption?.label ||
+    (publicData?.brand
+      ? publicData.brand.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+      : '');
+
   const richTitle = (
     <span>
       {richText(title, {
@@ -474,7 +486,7 @@ const pendingIsApproved = isPendingApprovalVariant && isApproved;
         }}
         className={css.brandLinkText}
       >
-        {publicData.brand.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
+        {brandLabel}
       </NamedLink>
     ) : null}
   </div>


### PR DESCRIPTION
## Summary
On the listing page, the brand was rendered by title-casing the raw stored option value (e.g. `afrm` → `Afrm`), which broke brand branding. It now displays the brand's configured option **label** (e.g. `AFRM`).

## Change
`ListingPageCarousel.js`: resolve the brand's display text from the listing field config's `enumOptions` — match the stored value to its option and use that option's `label`. Falls back to the previous title-cased value only when no matching label is configured. This mirrors the label-resolution pattern already used in `SectionDetailsMaybe`.

Note: the brand search/filter link still uses the raw option value (`pub_brand=...`), so filtering is unaffected.

## Testing
- `prettier --check` is clean on the changed lines (pre-existing unrelated formatting in this file was intentionally left untouched to keep the diff minimal).
- Verify locally via `npm run dev`: a listing whose brand option is `afrm` now shows `AFRM`.