### PR TITLE
Fix/return overdue sms state and duedate

### DIFF
--- a/server/api-util/integrationSdk.js
+++ b/server/api-util/integrationSdk.js
@@ -130,6 +130,10 @@ const ALLOWED_PROTECTED_DATA_KEYS = [
   'lastTrackingStatus',
   // Cross-process flags for return-reminder SMS dedupe (H2).
   'returnSms',
+  // Idempotency marker written by sendAutoCancelUnshipped.js after it cancels an
+  // unshipped booking (voids labels + sends 3.2/3.2b SMS). Must persist or the
+  // cancel + void path can re-fire on subsequent cron runs.
+  'autoCancel',
 ];
 
 /**

--- a/server/api-util/integrationSdk.js
+++ b/server/api-util/integrationSdk.js
@@ -92,8 +92,36 @@ const ALLOWED_PROTECTED_DATA_KEYS = [
   'outboundLabelUrl',
   'outboundTrackingNumber',
   'outboundTrackingUrl',
+  // Canonical outbound keys actually written by the accept flow
+  // (transition-privileged.js ~1302-1306). The legacy 'outboundQrCodeUrl'
+  // entry above is read by ship.js but never written — the writer uses
+  // 'outboundQrUrl'. These siblings were also being stripped on every persist.
+  'outboundQrUrl',
+  'outboundCarrier',
+  'outboundService',
+  'outboundQrExpiry',
+  'outboundPurchasedAt',
+  // Durable Shippo transaction object_id handles. Read by sendAutoCancelUnshipped.js
+  // (pd.outboundTransactionId / pd.returnTransactionId) to void unused labels, and
+  // used by resolveReturnLabelUrl() to re-fetch a label URL from Shippo when the
+  // persisted URL fields are absent. Previously never persisted AND not whitelisted.
+  'outboundTransactionId',
+  'returnTransactionId',
   'returnQrCodeUrl',
   'returnTrackingUrl',
+  // Canonical return-label keys written by the accept flow
+  // (transition-privileged.js ~1751-1758 and the returnNotification persist ~1831).
+  // These were MISSING from the whitelist, so pruneProtectedData() stripped them on
+  // every protectedData write and the return label/QR never persisted → the
+  // return-reminder and overdue SMS jobs read [NO-LABEL]. This is the root-cause fix.
+  'returnQrUrl',
+  'returnLabelUrl',
+  'returnTrackingNumber',
+  'returnCarrier',
+  'returnService',
+  'returnQrExpiry',
+  'returnPurchasedAt',
+  'returnNotification',
   'borrowerReturnLabelEmailSent', // Email idempotency flag for borrower return label emails
   'lenderOutboundLabelEmailSent', // Email idempotency flag for lender outbound label emails
   // Webhook-written scan/status state. Required by hasOutboundScan() and by

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -1296,6 +1296,7 @@ async function createShippingLabels({
     
     try {
       const patch = {
+        outboundTransactionId: shippoTransactionId || null, // durable Shippo handle (void + label re-fetch)
         outboundTrackingNumber: trackingNumber,
         outboundTrackingUrl: trackingUrl,
         outboundLabelUrl: labelUrl,
@@ -1748,6 +1749,7 @@ async function createShippingLabels({
             // Persist return label details to Flex protectedData
             try {
               const patch = {
+                returnTransactionId: returnTransactionRes.data.object_id || null, // durable Shippo handle (void + label re-fetch)
                 returnTrackingNumber: returnTransactionRes.data.tracking_number || null,
                 returnTrackingUrl: returnTrackingUrl,
                 returnLabelUrl: returnTransactionRes.data.label_url || null,

--- a/server/lib/lateFees.js
+++ b/server/lib/lateFees.js
@@ -160,10 +160,10 @@ async function applyCharges({ sdkInstance, txId, now }) {
   try {
     console.log(`[lateFees] Processing transaction ${txId}...`);
     
-    // Load transaction with listing data
+    // Load transaction with listing + booking data
     const response = await sdkInstance.transactions.show({
       id: txId,
-      include: ['listing']
+      include: ['listing', 'booking']
     });
     
     const tx = response.data.data;
@@ -202,8 +202,15 @@ async function applyCharges({ sdkInstance, txId, now }) {
     
     // Determine return due date
     // Priority 1: Explicit return.dueAt
-    // Priority 2: booking.end (deliveryEnd)
-    const returnDueAt = returnData.dueAt || tx.attributes?.booking?.end;
+    // Priority 2: booking.end resolved from the INCLUDED booking resource.
+    //   booking is a relationship, not a tx attribute, so tx.attributes.booking?.end
+    //   is always undefined; the show() above now includes 'booking'.
+    const bookingRef = tx.relationships?.booking?.data;
+    const bookingKey = bookingRef ? `${bookingRef.type}/${bookingRef.id?.uuid || bookingRef.id}` : null;
+    const includedBookingEnd = bookingKey
+      ? included.find(i => `${i.type}/${i.id.uuid || i.id}` === bookingKey)?.attributes?.end
+      : null;
+    const returnDueAt = returnData.dueAt || tx.attributes?.booking?.end || includedBookingEnd;
     
     if (!returnDueAt) {
       throw new Error(

--- a/server/lib/shippo.js
+++ b/server/lib/shippo.js
@@ -67,6 +67,78 @@ async function voidShippoLabel(shippoTransactionId) {
   return data;
 }
 
+/**
+ * Retrieve a single Shippo transaction (label) by its object_id.
+ *
+ * API: GET https://api.goshippo.com/transactions/{object_id}
+ *
+ * @param {string} objectId - Shippo transaction object_id (stored on
+ *   protectedData.returnTransactionId / protectedData.outboundTransactionId).
+ * @returns {Promise<object|null>} - Parsed transaction object (includes
+ *   label_url, qr_code_url, tracking_number, tracking_url_provider, status),
+ *   or null if missing/unfetchable. Never throws.
+ */
+async function getShippoTransaction(objectId) {
+  if (!objectId) return null;
+
+  const token = getShippoToken();
+  const url = `${SHIPPO_API_BASE}/transactions/${encodeURIComponent(objectId)}`;
+
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Authorization': `ShippoToken ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => '<no body>');
+    console.warn(
+      `[shippo] getShippoTransaction(${objectId}) failed (${res.status}): ${errorText}`
+    );
+    return null;
+  }
+
+  return res.json();
+}
+
+/**
+ * Resolve the best available return-label link from a transaction's
+ * protectedData, with a Shippo re-fetch fallback.
+ *
+ * Order of preference:
+ *   1. pd.returnQrUrl    (USPS QR code — preferred)
+ *   2. pd.returnLabelUrl (PDF label — fallback)
+ *   3. Re-fetch from Shippo via pd.returnTransactionId, then qr_code_url || label_url
+ *
+ * The whitelist fix in api-util/integrationSdk.js means returnQrUrl/returnLabelUrl
+ * now persist directly, so case 3 is defense-in-depth for transactions where the
+ * URL fields are somehow absent but the durable object_id survived.
+ *
+ * @param {object} pd - transaction protectedData
+ * @returns {Promise<{url: string, type: 'QR'|'label', source: string}|null>}
+ */
+async function resolveReturnLabelUrl(pd) {
+  if (!pd || typeof pd !== 'object') return null;
+
+  if (pd.returnQrUrl) return { url: pd.returnQrUrl, type: 'QR', source: 'returnQrUrl' };
+  if (pd.returnLabelUrl) return { url: pd.returnLabelUrl, type: 'label', source: 'returnLabelUrl' };
+
+  const objectId = pd.returnTransactionId || (pd.return && pd.return.transactionId);
+  if (!objectId) return null;
+
+  try {
+    const txn = await getShippoTransaction(objectId);
+    if (txn && txn.qr_code_url) return { url: txn.qr_code_url, type: 'QR', source: 'shippo:qr' };
+    if (txn && txn.label_url) return { url: txn.label_url, type: 'label', source: 'shippo:label' };
+  } catch (e) {
+    console.warn(`[shippo] resolveReturnLabelUrl re-fetch failed for ${objectId}: ${e.message}`);
+  }
+  return null;
+}
+
 module.exports = {
   voidShippoLabel,
+  getShippoTransaction,
+  resolveReturnLabelUrl,
 };

--- a/server/lib/shippo.js
+++ b/server/lib/shippo.js
@@ -9,6 +9,10 @@
 
 const SHIPPO_API_BASE = 'https://api.goshippo.com';
 
+// Bound every Shippo GET so a stalled API call can't block a per-tx cron loop
+// (a hung request would otherwise hold the 24h per-tx Redis lock for the day).
+const SHIPPO_FETCH_TIMEOUT_MS = 8000;
+
 function getShippoToken() {
   const token = process.env.SHIPPO_API_TOKEN;
   if (!token) {
@@ -76,30 +80,49 @@ async function voidShippoLabel(shippoTransactionId) {
  *   protectedData.returnTransactionId / protectedData.outboundTransactionId).
  * @returns {Promise<object|null>} - Parsed transaction object (includes
  *   label_url, qr_code_url, tracking_number, tracking_url_provider, status),
- *   or null if missing/unfetchable. Never throws.
+ *   or null on ANY failure (missing token, non-2xx, network error, timeout).
+ *   Never throws — safe to call from a cron loop without a try/catch.
  */
 async function getShippoTransaction(objectId) {
   if (!objectId) return null;
 
-  const token = getShippoToken();
-  const url = `${SHIPPO_API_BASE}/transactions/${encodeURIComponent(objectId)}`;
-
-  const res = await fetch(url, {
-    method: 'GET',
-    headers: {
-      'Authorization': `ShippoToken ${token}`,
-    },
-  });
-
-  if (!res.ok) {
-    const errorText = await res.text().catch(() => '<no body>');
-    console.warn(
-      `[shippo] getShippoTransaction(${objectId}) failed (${res.status}): ${errorText}`
-    );
+  let token;
+  try {
+    token = getShippoToken();
+  } catch (e) {
+    console.warn(`[shippo] getShippoTransaction(${objectId}) skipped: ${e.message}`);
     return null;
   }
 
-  return res.json();
+  const url = `${SHIPPO_API_BASE}/transactions/${encodeURIComponent(objectId)}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SHIPPO_FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': `ShippoToken ${token}`,
+      },
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text().catch(() => '<no body>');
+      console.warn(
+        `[shippo] getShippoTransaction(${objectId}) failed (${res.status}): ${errorText}`
+      );
+      return null;
+    }
+
+    return await res.json();
+  } catch (e) {
+    const reason = e.name === 'AbortError' ? `timeout after ${SHIPPO_FETCH_TIMEOUT_MS}ms` : e.message;
+    console.warn(`[shippo] getShippoTransaction(${objectId}) request error: ${reason}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**

--- a/server/scripts/sendOverdueReminders.js
+++ b/server/scripts/sendOverdueReminders.js
@@ -46,6 +46,7 @@ const { sendSMS: sendSMSOriginal } = require('../api-util/sendSMS');
 const { maskPhone } = require('../api-util/phone');
 const { shortLink } = require('../api-util/shortlink');
 const { applyCharges } = require('../lib/lateFees');
+const { resolveReturnLabelUrl } = require('../lib/shippo');
 const { getRedis } = require('../redis');
 const {
   ymd,
@@ -700,13 +701,17 @@ async function sendOverdueReminders() {
           if (ONLY_PHONE && borrowerPhone !== ONLY_PHONE) {
             if (VERBOSE) console.log(`↩️ Skipping ${borrowerPhone} (ONLY_PHONE=${ONLY_PHONE})`);
           } else {
-            // Canonical return-label URL (9.1 spec: two fields only)
-            const returnLabelUrl = protectedData.returnQrUrl || protectedData.returnLabelUrl;
+            // Canonical return-label URL, with Shippo re-fetch fallback (matches
+            // sendReturnReminders.js): prefer returnQrUrl/returnLabelUrl, else recover
+            // from Shippo via returnTransactionId.
+            const resolvedLabel = await resolveReturnLabelUrl(protectedData);
 
-            if (!returnLabelUrl) {
-              console.warn(`[OVERDUE][NO-LABEL] tx=${txId} day=${daysLate} — no returnQrUrl or returnLabelUrl, skipping SMS`);
+            if (!resolvedLabel) {
+              console.warn(`[OVERDUE][NO-LABEL] tx=${txId} day=${daysLate} — no returnQrUrl/returnLabelUrl and no Shippo re-fetch via returnTransactionId, skipping SMS`);
               continue;
             }
+
+            const returnLabelUrl = resolvedLabel.url;
 
             let shortUrl = returnLabelUrl;
             try {

--- a/server/scripts/sendOverdueReminders.js
+++ b/server/scripts/sendOverdueReminders.js
@@ -340,7 +340,7 @@ async function sendOverdueReminders() {
     for (const state of statesToQuery) {
       const query = {
         state: state,
-        include: ['customer', 'listing'],
+        include: ['customer', 'listing', 'booking'],
         per_page: 100  // snake_case for Marketplace SDK
       };
 
@@ -433,7 +433,15 @@ async function sendOverdueReminders() {
         continue;
       }
       
-      const deliveryEnd = tx?.attributes?.deliveryEnd || tx?.attributes?.booking?.end;
+      // Resolve the booking end from the INCLUDED booking resource (the query now
+      // includes 'booking'). Sharetribe exposes booking as a relationship, not a tx
+      // attribute, so tx.attributes.booking?.end is always undefined and
+      // returnData.dueAt is never persisted — without this the due date can't be
+      // resolved and every tx was skipped with "no return due date".
+      const bookingRef = tx?.relationships?.booking?.data;
+      const bookingKey = bookingRef ? `${bookingRef.type}/${bookingRef.id?.uuid || bookingRef.id}` : null;
+      const includedBookingEnd = bookingKey ? included.get(bookingKey)?.attributes?.end : null;
+      const deliveryEnd = tx?.attributes?.deliveryEnd || includedBookingEnd;
       const returnDueAt = returnData.dueAt || deliveryEnd;
       
       if (!returnDueAt) {

--- a/server/scripts/sendReturnReminders.js
+++ b/server/scripts/sendReturnReminders.js
@@ -54,6 +54,7 @@ const { getFirstChargeableLateDate } = require('../lib/businessDays');
 const { getRedis } = require('../redis');
 const { withinSendWindow, getNow } = require('../util/time');
 const { upsertProtectedData } = require('../lib/txData');
+const { resolveReturnLabelUrl } = require('../lib/shippo');
 
 // In-memory guards to avoid repeat sends within the same daemon process
 // if Flex protectedData updates fail. Keys are txId → local date string.
@@ -102,7 +103,9 @@ if (DRY) {
     const bodyJson = JSON.stringify(body);
     console.log(`[SMS:OUT] tag=${tag || 'none'} to=${to} meta=${metaJson} body=${bodyJson} dry-run=true`);
     if (VERBOSE) console.log('opts:', opts);
-    return { dryRun: true };
+    // Match the real sendSMS skip envelope so the post-send block treats dry-run
+    // as "not sent" and does NOT write idempotency markers to production data.
+    return { skipped: true, reason: 'dry_run', dryRun: true };
   };
 }
 
@@ -248,7 +251,11 @@ async function sendReturnReminders(allowExitOnError = true) {
     const PAGE_SIZE = parseInt(process.env.ONLY_PAGE_SIZE || process.env.PER_PAGE || '5', 10) || 5;
 
     const baseQuery = {
-      state: ONLY_STATE || 'delivered',
+      // Return reminders fire while the item is OUT with the borrower — that is
+      // state/accepted (active rental + return window). state/delivered means the
+      // RETURN already completed (item back to lender via complete-return), so it
+      // must NOT be the target or the reminder can never match a live rental.
+      state: ONLY_STATE || 'accepted',
       include: ['customer', 'listing', 'booking', 'provider'],
       per_page: PAGE_SIZE, // narrow default; env overrides above
     };
@@ -258,7 +265,7 @@ async function sendReturnReminders(allowExitOnError = true) {
       try {
         console.log('[RETURN-REMINDER-SELFTEST] running minimal Flex access check');
         const selfTestQuery = {
-          state: ONLY_STATE || 'delivered',
+          state: ONLY_STATE || 'accepted',
           include: [],
           per_page: 1,
           page: 1,
@@ -269,14 +276,14 @@ async function sendReturnReminders(allowExitOnError = true) {
         console.log(`[RETURN-REMINDER-SELFTEST] success firstTx=${first || 'none'}`);
         return;
       } catch (err) {
-        logAxios(err, `sdk.transactions.query selftest state=${ONLY_STATE || 'delivered'}`);
+        logAxios(err, `sdk.transactions.query selftest state=${ONLY_STATE || 'accepted'}`);
         if (allowExitOnError) process.exit(1);
         return;
       }
     }
 
     const ONLY_TX = process.env.ONLY_TX;
-  const onlyTxId = ONLY_TX && ONLY_TX.includes('-') ? { uuid: ONLY_TX } : ONLY_TX;
+  const onlyTxId = ONLY_TX; // bare UUID string; Integration SDK rejects a plain { uuid } object here
 
     let sent = 0, failed = 0, processed = 0;
     let totalCandidates = 0;
@@ -327,7 +334,7 @@ async function sendReturnReminders(allowExitOnError = true) {
         //      Catches inquiry/pending-payment/preauthorized/accepted etc.
         // Integration SDK returns "state/delivered"; marketplace SDK may
         // return bare "delivered" — strip the "state/" prefix to accept both.
-        const expectedState = ONLY_STATE || 'delivered';
+        const expectedState = ONLY_STATE || 'accepted';
         const txState = tx?.attributes?.state || '';
         const normalizedTxState = txState.replace(/^state\//, '');
         if (TERMINAL_STATES_DENYLIST.has(normalizedTxState)) {
@@ -351,8 +358,14 @@ async function sendReturnReminders(allowExitOnError = true) {
         const endsAtMidnight =
           bookingEndPT && bookingEndPT.format('HH:mm:ss') === '00:00:00';
 
+        // Use the booking-end calendar date as the return due date so the day-of
+        // (8-SMS) window aligns with the overdue script's due date and lands exactly
+        // one day before the first overdue reminder (9.1). The previous
+        // `endsAtMidnight ? subtract(1,'day')` shifted the due date a day early,
+        // which (combined with the inner TODAY check that used the un-subtracted
+        // booking end) meant the day-of reminder never fired.
         const dueLocalDate = bookingEndPT
-          ? (endsAtMidnight ? bookingEndPT.subtract(1, 'day') : bookingEndPT).format('YYYY-MM-DD')
+          ? bookingEndPT.format('YYYY-MM-DD')
           : null;
 
         const lateStartLocalDate = bookingEndPT ? bookingEndPT.format('YYYY-MM-DD') : null;
@@ -510,22 +523,33 @@ async function sendReturnReminders(allowExitOnError = true) {
             continue;
           }
 
-          // T-1 day: Send QR/label (use real label if available)
-          // Canonical fields only: pd.returnQrUrl (preferred) / pd.returnLabelUrl (fallback).
-          // These are written atomically at the accept transition — if both are missing,
-          // skip this pass and let the next cron cycle or LATE reminder pick it up.
-          const returnLabelUrl = pd.returnQrUrl || pd.returnLabelUrl;
-
-          if (!returnLabelUrl) {
-            console.warn(`[RETURN-REMINDER][NO-LABEL] tx=${tx?.id?.uuid || '(no id)'} — no pd.returnQrUrl or pd.returnLabelUrl. Skipping this pass.`);
+          // Skip if the return is already in motion (mirrors the TODAY branch):
+          // no point telling someone to "ship back tomorrow" once they've shipped.
+          if (
+            returnData.firstScanAt ||
+            returnData.status === 'in_transit' ||
+            returnData.status === 'accepted'
+          ) {
+            console.log(`[return-reminders] 🚚 Return already scanned/in transit for tx ${tx?.id?.uuid || '(no id)'} - skipping T-1 reminder`);
             continue;
           }
 
-          // Log whether we're using QR or label URL
-          const labelType = pd.returnQrUrl ? 'QR' : 'label';
-          const labelSource = pd.returnQrUrl ? 'returnQrUrl' : 'returnLabelUrl';
-          console.log(`[return-reminders] Using ${labelType} URL from ${labelSource} for tx ${tx?.id?.uuid || '(no id)'}`);
-          
+          // T-1 day: Send QR/label (use real label if available)
+          // Canonical fields preferred: pd.returnQrUrl / pd.returnLabelUrl. If both
+          // are absent, fall back to re-fetching from Shippo via pd.returnTransactionId
+          // (defense-in-depth — see resolveReturnLabelUrl). If nothing resolves, skip
+          // this pass and let the next cron cycle pick it up.
+          const resolvedLabel = await resolveReturnLabelUrl(pd);
+
+          if (!resolvedLabel) {
+            console.warn(`[RETURN-REMINDER][NO-LABEL] tx=${tx?.id?.uuid || '(no id)'} — no returnQrUrl/returnLabelUrl and no Shippo re-fetch via returnTransactionId. Skipping this pass.`);
+            continue;
+          }
+
+          const returnLabelUrl = resolvedLabel.url;
+          // Log whether we're using QR or label URL, and where it came from
+          console.log(`[return-reminders] Using ${resolvedLabel.type} URL from ${resolvedLabel.source} for tx ${tx?.id?.uuid || '(no id)'}`);
+
           const shortUrl = await shortLink(returnLabelUrl);
           console.log('[SMS] shortlink', { type: 'return', short: shortUrl, original: returnLabelUrl });
           message = `📦 Sherbrt 🍧: It's almost return time! Use your QR/label to ship "${itemTitle}" back tomorrow: ${shortUrl}.`;
@@ -579,12 +603,13 @@ async function sendReturnReminders(allowExitOnError = true) {
             continue;
           }
           
-          // Canonical fields only — matches T-1 branch.
-          const returnLabelUrl = pd.returnQrUrl || pd.returnLabelUrl;
+          // Canonical fields preferred, Shippo re-fetch fallback — matches T-1 branch.
+          const resolvedLabel = await resolveReturnLabelUrl(pd);
 
-          if (returnLabelUrl) {
+          if (resolvedLabel) {
+            const returnLabelUrl = resolvedLabel.url;
             const shortUrl = await shortLink(returnLabelUrl);
-            console.log('[SMS] shortlink', { type: 'return', short: shortUrl, original: returnLabelUrl });
+            console.log('[SMS] shortlink', { type: 'return', short: shortUrl, original: returnLabelUrl, source: resolvedLabel.source });
             message = `⏰ Sherbrt 🍧: Today's the day for you to ship back "${itemTitle}"! Late returns may incur $15/day fees. Use your QR/label to ship back: ${shortUrl}.`;
             tag = 'return_reminder_today';
           } else {
@@ -760,6 +785,10 @@ async function sendReturnReminders(allowExitOnError = true) {
           id: onlyTxId,
           include: ['customer', 'listing', 'booking', 'provider'],
         });
+        // show() returns a single object; processTxPage expects a query-shaped array.
+        if (res?.data && !Array.isArray(res.data.data)) {
+          res.data.data = [res.data.data];
+        }
         await processTxPage(res, { pageLabel: 'ONLY_TX' });
       } catch (err) {
         logAxios(err, `sdk.transactions.show ONLY_TX=${ONLY_TX} idShape=${safeStringify(onlyTxId, 200)}`);


### PR DESCRIPTION
## What & why
Return-reminder (SMS 7/8) and overdue (SMS 9.x) texts weren't reaching borrowers.

**Root cause:** `ALLOWED_PROTECTED_DATA_KEYS` in `server/api-util/integrationSdk.js`
was missing the canonical return-label keys, so `pruneProtectedData()` stripped
`returnQrUrl`/`returnLabelUrl`/`returnTrackingNumber` on every protectedData write.
The label/QR never persisted and the cron jobs read `[NO-LABEL]`.

## Changes
- **integrationSdk.js**: whitelist the canonical return keys + outbound parallels +
  `returnTransactionId`/`outboundTransactionId` + `autoCancel`.
- **transition-privileged.js**: persist the Shippo transaction `object_id` for both
  outbound and return labels (also unblocks the `sendAutoCancelUnshipped` void path).
- **shippo.js**: add `getShippoTransaction()` (8s timeout, never throws) and
  `resolveReturnLabelUrl()` re-fetch fallback.
- **sendReturnReminders.js**: target state `accepted` (not `delivered`); fix off-by-one
  due date; add T-1 no-scan gate; dry-run no longer writes; use `resolveReturnLabelUrl`.
- **sendOverdueReminders.js + lateFees.js**: include `booking` so the return due date
  resolves; overdue SMS uses the same Shippo fallback.

## Testing
All affected jest suites pass (integrationSdk whitelist/transition, both reminder
scripts, transition-privileged accept flow). Late-fee math is unchanged — the due-date
change only affects reminder timing.

## Notes
- No data backfill needed (only one stale test transaction).
- Reviewed by Claude Code before merge.