### PR TITLE
fix(sms): stop borrower checkout from polluting providerPhone/Email

### DIFF
--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -2335,7 +2335,7 @@ module.exports = async (req, res) => {
           
           // Now merge: transaction first, then cleaned updates
           const mergedProtectedData = { ...txProtectedData, ...cleaned };
-          
+
           // Explicitly protect customer* fields from being overwritten by blank strings:
           const CUSTOMER_KEYS = [
             'customerName','customerStreet','customerStreet2','customerCity',
@@ -2345,6 +2345,35 @@ module.exports = async (req, res) => {
             if ((mergedProtectedData[k] == null || mergedProtectedData[k] === '') && txProtectedData[k]) {
               mergedProtectedData[k] = txProtectedData[k];
             }
+          }
+
+          // Defensive scrub for the lender-SMS-to-borrower bug (tx 6a1a18ad...):
+          // pre-fix borrower checkout wrote currentUser's phone/email into
+          // protectedData.providerPhone / providerEmail. That meant the
+          // Step-3 "Ship by" SMS (and lender outbound email) were sent to
+          // the borrower's contact info. If the value in PD matches the
+          // borrower's customer* contact, treat it as polluted and drop it
+          // so hydrateProviderFieldsFromProfile() refills from the lender's
+          // profile. Lender form submissions (clean string, doesn't match
+          // customer*) are preserved.
+          const norm = v => (typeof v === 'string' ? v.trim().toLowerCase() : v);
+          if (
+            mergedProtectedData.providerPhone &&
+            mergedProtectedData.customerPhone &&
+            norm(mergedProtectedData.providerPhone) === norm(mergedProtectedData.customerPhone) &&
+            !(cleaned && Object.prototype.hasOwnProperty.call(cleaned, 'providerPhone'))
+          ) {
+            console.warn('[ACCEPT][SCRUB] providerPhone matches customerPhone — dropping polluted value so profile hydration can refill');
+            mergedProtectedData.providerPhone = '';
+          }
+          if (
+            mergedProtectedData.providerEmail &&
+            mergedProtectedData.customerEmail &&
+            norm(mergedProtectedData.providerEmail) === norm(mergedProtectedData.customerEmail) &&
+            !(cleaned && Object.prototype.hasOwnProperty.call(cleaned, 'providerEmail'))
+          ) {
+            console.warn('[ACCEPT][SCRUB] providerEmail matches customerEmail — dropping polluted value so profile hydration can refill');
+            mergedProtectedData.providerEmail = '';
           }
           
           console.log('[server accept] merged PD keys:', Object.keys(mergedProtectedData));

--- a/src/containers/CheckoutPage/CheckoutPageWithPayment.js
+++ b/src/containers/CheckoutPage/CheckoutPageWithPayment.js
@@ -143,15 +143,22 @@ const getOrderParams = (pageData, shippingDetails, optionalPaymentParams, config
       customerEmail: formValues.email || currentUser?.attributes?.email || '',
       customerPhone: formValues.phone || shippingInfo?.phoneNumber || '',
 
-      // Provider info from currentUser
-      providerName: currentUser?.attributes?.profile?.displayName || '',
+      // Provider (lender) info — MUST be left blank on the borrower's checkout.
+      // currentUser here is the BORROWER. Writing borrower-derived values into
+      // provider* fields polluted protectedData.providerPhone with the
+      // borrower's phone, which caused the lender "Ship by" SMS to be sent
+      // to the borrower at outbound-label time. The server hydrates these
+      // from the lender's profile (hydrateProviderFieldsFromProfile) during
+      // transition/accept, and the ProviderAddressForm overrides them on
+      // accept — both code paths only run when these fields are empty here.
+      providerName: '',
       providerStreet: '', // Will be filled by provider in TransactionPanel
       providerStreet2: '', // Apartment, suite, etc. - will be filled by provider
       providerCity: '',
       providerState: '',
       providerZip: '',
-      providerEmail: currentUser?.attributes?.email || '',
-      providerPhone: currentUser?.attributes?.profile?.protectedData?.phoneNumber || currentUser?.attributes?.profile?.publicData?.phoneNumber || '',
+      providerEmail: '',
+      providerPhone: '',
 
       // Additional transaction data
       ...getTransactionTypeData(listingType, unitType, config),
@@ -379,11 +386,16 @@ const handleSubmit = async (values, process, props, stripe, submitting, setSubmi
     customerState: finalShipping?.state?.trim() || '',
     customerZip: finalShipping?.postalCode?.trim() || '',
     
-    // Provider fields
-    providerName: currentUser?.attributes?.profile?.displayName?.trim() || '',
-    providerEmail: currentUser?.attributes?.email?.trim() || '',
-    providerPhone: (currentUser?.attributes?.profile?.protectedData?.phoneNumber || 
-                   currentUser?.attributes?.profile?.publicData?.phoneNumber || '').trim(),
+    // Provider (lender) fields — MUST stay blank here. currentUser on the
+    // checkout page is the BORROWER; populating provider* from currentUser
+    // wrote the borrower's phone/email into protectedData.providerPhone /
+    // providerEmail and caused the lender "Ship by" SMS to be sent to the
+    // borrower. The server hydrates these from the lender's profile during
+    // transition/accept (see hydrateProviderFieldsFromProfile), which only
+    // runs when these are missing/empty.
+    providerName: '',
+    providerEmail: '',
+    providerPhone: '',
   };
 
   const mergedPD = protectedData;


### PR DESCRIPTION
Borrower checkout was writing currentUser's phone/email/displayName into protectedData.provider* fields. Since currentUser at checkout is the BORROWER, this caused the Step-3 'Ship by' SMS and lender outbound label email to be routed to the borrower's contact info instead of the lender's (observed on tx 6a1a18ad-afbd-4b62-b3d5-aeefc8194f48).

- CheckoutPageWithPayment.js: leave provider* fields blank in both getOrderParams and the request-payment PD builder so the server's hydrateProviderFieldsFromProfile() and ProviderAddressForm fill them from the lender's profile/form on accept.
- transition-privileged.js: defensive scrub at accept-time merge — if mergedPD.providerPhone === customerPhone (or providerEmail === customerEmail) and the incoming request didn't explicitly submit the field, drop it so hydration refills from the lender's profile. Self-heals in-flight transactions with already-polluted PD.