### PR TITLE
fix(ship-by): clamp shipByDate to today so SMS never says ship by a p…

### DIFF
--- a/server/lib/shipping.computeShipByDate.test.js
+++ b/server/lib/shipping.computeShipByDate.test.js
@@ -13,6 +13,16 @@
  * invoke `.getUTCDay()` and `.toISOString()` without type-mismatches.
  */
 
+// Pin "now" before requiring computeShipByDate so the new past-date clamp
+// (which calls getNow() → respects FORCE_NOW) does not turn the fixed
+// April-2026 test dates into "today" and break the suite.
+const ORIGINAL_FORCE_NOW = process.env.FORCE_NOW;
+process.env.FORCE_NOW = '2026-04-01T00:00:00.000Z';
+afterAll(() => {
+  if (ORIGINAL_FORCE_NOW === undefined) delete process.env.FORCE_NOW;
+  else process.env.FORCE_NOW = ORIGINAL_FORCE_NOW;
+});
+
 const { computeShipByDate } = require('./shipping');
 const dayjs = require('dayjs');
 dayjs.extend(require('dayjs/plugin/utc'));

--- a/server/lib/shipping.js
+++ b/server/lib/shipping.js
@@ -1,6 +1,16 @@
 // server/lib/shipping.js
 const { haversineMiles, geocodeZip } = require('./geo');
 const { subtractBusinessDays } = require('./businessDays');
+const { getNow } = require('../util/time');
+
+// Helper: today at UTC midnight (respects FORCE_NOW via getNow()).
+// Used to clamp shipByDate so we never tell a lender to ship in the past
+// when they accept within the lead-day window of the booking start.
+function _todayUTCMidnight() {
+  const today = getNow();
+  today.setUTCHours(0, 0, 0, 0);
+  return today;
+}
 
 // Buffer days added to `estimated_days` for shipBy derivation (10.0 PR-2).
 const SAFETY_BUFFER_DAYS = Number(process.env.SHIP_SAFETY_BUFFER || 1);
@@ -171,6 +181,19 @@ async function computeShipByDate(tx, opts = {}) {
   if (persisted) {
     const d = new Date(persisted);
     if (!Number.isNaN(+d)) {
+      // Clamp: a persisted ship-by date in the past (e.g., lender accepted
+      // within the lead-day window of booking start, so the originally
+      // computed date was already yesterday) must surface as "today" so
+      // downstream SMS / email never tells the lender to ship in the past.
+      const today = _todayUTCMidnight();
+      if (d < today) {
+        console.warn('[ship-by:persisted:clamp]', {
+          persistedISO: persisted,
+          todayISO: today.toISOString(),
+          txId: tx?.id?.uuid,
+        });
+        return today;
+      }
       console.log('[ship-by:persisted]', {
         shipByISO: persisted,
         txId: tx?.id?.uuid,
@@ -208,15 +231,30 @@ async function computeShipByDate(tx, opts = {}) {
   const ADJUST_SUNDAY = String(process.env.SHIP_ADJUST_SUNDAY || '1') === '1';
   const adjusted = ADJUST_SUNDAY ? adjustIfSundayUTC(shipBy) : shipBy;
 
+  // Clamp: if the computed date is already in the past (lender accepted
+  // close to or after the lead-day window), surface "today" instead of
+  // a past date — the SMS would otherwise say "ship by [yesterday]".
+  const today = _todayUTCMidnight();
+  const final = adjusted < today ? today : adjusted;
+  if (final !== adjusted) {
+    console.warn('[ship-by:computed:clamp]', {
+      computedISO: adjusted.toISOString(),
+      todayISO: today.toISOString(),
+      startISO,
+      leadDays,
+    });
+  }
+
   console.log('[ship-by:computed]', {
     startISO,
     transitDays: transitDays ?? null,
     leadDays,
     mode: transitDays != null ? 'shippo-anchored' : 'static-fallback',
-    shipByISO: adjusted.toISOString(),
+    shipByISO: final.toISOString(),
+    clamped: final !== adjusted,
   });
 
-  return adjusted;
+  return final;
 }
 
 /**


### PR DESCRIPTION
…ast date

When a lender accepts within the lead-day window of the booking start (observed today: accept on Fri May 29, booking start Mon Jun 1, lead 2 BD → computed ship-by Thu May 28, yesterday), the Step-3 'Ship by' SMS rendered the past date verbatim.

- computeShipByDate now clamps both branches (persisted and computed) to today at UTC midnight via getNow() so FORCE_NOW continues to work.
- New [ship-by:persisted:clamp] / [ship-by:computed:clamp] warn logs surface in Render whenever the clamp activates.
- Test suite pins FORCE_NOW to 2026-04-01 so the fixed April-2026 test dates aren't themselves clamped to today and don't break.