### PR TITLE
fix(sms-cron): tighten Mon-start auto-cancel + fix return T-1 off-by-…

### DIFF
--- a/server/scripts/sendAutoCancelUnshipped.js
+++ b/server/scripts/sendAutoCancelUnshipped.js
@@ -53,19 +53,20 @@ const SCAN_LAG_GRACE_HOURS = 12;
 /**
  * Returns the cancel deadline as a moment in lender-local time.
  *
- * Base rule: 11:59pm lender-local on booking start date (D).
- * Monday grace: If D falls on a Monday, shift to 11:59pm Tuesday (D+1).
+ * Rule: 11:59pm lender-local on booking start date (D), for every day of
+ * the week. The previous Monday-only +24h grace was dropped — combined
+ * with the downstream 12h scan-lag grace it pushed Monday-start auto-
+ * cancels to Wed ~noon, which was too generous and didn't match the
+ * intent of the auto-cancel-for-non-shipment policy. Monday is now
+ * treated like any other start day → deadline Mon 23:59:59 PT, then
+ * scan-lag grace adds +12h → cron fires Tue ~noon PT.
  */
 function getCancelDeadline(bookingStartUtc, lenderTz) {
   const tz = lenderTz || DEFAULT_LENDER_TZ;
   const bookingStartDate = moment.utc(bookingStartUtc).format('YYYY-MM-DD');
   // End-of-day = 23:59:59 (not 23:59:00) so the "11:59pm" intent is honored
   // to the second rather than being 59s early.
-  let deadline = moment.tz(`${bookingStartDate} 23:59:59`, 'YYYY-MM-DD HH:mm:ss', tz);
-  if (deadline.day() === 1 /* Monday */) {
-    deadline = deadline.add(1, 'day');
-  }
-  return deadline;
+  return moment.tz(`${bookingStartDate} 23:59:59`, 'YYYY-MM-DD HH:mm:ss', tz);
 }
 
 function isPastCancelDeadline(now, bookingStartUtc, lenderTz) {
@@ -110,8 +111,17 @@ async function fetchAcceptedBookings(sdk) {
   // (incorrect for anyone outside PT). Fetching the full listing resource is
   // the safe default. `fields.provider`/`fields.customer` are fine because we
   // only read `profile` off those, which is whitelisted.
+  // The previous `state: 'accepted'` filter is silently ignored by the
+  // Marketplace API v2 query. Use lastTransitions instead so we only pull
+  // txs whose last transition left them in :state/accepted in the
+  // default-booking process (per ext/transaction-processes/default-
+  // booking/process.edn). Belt-and-suspenders idempotency + booking.status
+  // gates downstream catch anything that slips through.
   const res = await sdk.transactions.query({
-    state: 'accepted',
+    lastTransitions: [
+      'transition/accept',
+      'transition/operator-update-pd-accepted',
+    ],
     include: ['booking', 'listing', 'provider', 'customer'],
     'fields.provider': 'profile',
     'fields.customer': 'profile',

--- a/server/scripts/sendReturnReminders.js
+++ b/server/scripts/sendReturnReminders.js
@@ -400,21 +400,32 @@ async function sendReturnReminders(allowExitOnError = true) {
         const bookingKey = bookingRef ? `${bookingRef.type}/${bookingRef.id?.uuid || bookingRef.id}` : null;
         const booking = bookingKey ? included.get(bookingKey) : null;
         const bookingEndRaw = booking?.attributes?.end || null;
+        const bookingEndUTC = bookingEndRaw ? dayjs.utc(bookingEndRaw) : null;
         const bookingEndPT = bookingEndRaw ? dayjs(bookingEndRaw).tz(TZ) : null;
         const endsAtMidnight =
           bookingEndPT && bookingEndPT.format('HH:mm:ss') === '00:00:00';
+        // Sharetribe day-bookings store booking.end at UTC midnight,
+        // end-exclusive. For a 2-night booking displayed "Mon Jun 1 — Wed
+        // Jun 3", booking.end = "2026-06-03T00:00:00Z" — the day the borrower
+        // ships back. The previous bookingEndPT.format() converted to PT
+        // first, yielding "2026-06-02" (since UTC midnight = 5 PM PT prev
+        // day) and made T-1 fire Mon Jun 1 instead of Tue Jun 2.
+        const endsAtUTCMidnight =
+          bookingEndUTC && bookingEndUTC.format('HH:mm:ss') === '00:00:00';
 
         // Use the booking-end calendar date as the return due date so the day-of
         // (8-SMS) window aligns with the overdue script's due date and lands exactly
-        // one day before the first overdue reminder (9.1). The previous
-        // `endsAtMidnight ? subtract(1,'day')` shifted the due date a day early,
-        // which (combined with the inner TODAY check that used the un-subtracted
-        // booking end) meant the day-of reminder never fired.
-        const dueLocalDate = bookingEndPT
-          ? bookingEndPT.format('YYYY-MM-DD')
+        // one day before the first overdue reminder (9.1). For UTC-midnight
+        // day-bookings (Sharetribe default), read the UTC calendar date so the
+        // due date matches Sharetribe's "Booking end" display; otherwise fall
+        // through to the PT-converted date for any future non-midnight ends.
+        const dueLocalDate = bookingEndUTC
+          ? (endsAtUTCMidnight
+              ? bookingEndUTC.format('YYYY-MM-DD')
+              : bookingEndPT.format('YYYY-MM-DD'))
           : null;
 
-        const lateStartLocalDate = bookingEndPT ? bookingEndPT.format('YYYY-MM-DD') : null;
+        const lateStartLocalDate = dueLocalDate;
         
         // [RETURN-REMINDER-DEBUG] Log transaction details for debugging
         console.log(`[RETURN-REMINDER-DEBUG] tx=${tx?.id?.uuid || tx?.id || '(no id)'} bookingEndRaw=${bookingEndRaw} bookingEndPT=${bookingEndPT ? bookingEndPT.format() : null} endsAtMidnight=${endsAtMidnight} dueLocalDate=${dueLocalDate} deliveryEndRaw=${deliveryEndRaw} deliveryEndNormalized=${deliveryEndNormalized} today=${today} tomorrow=${tomorrow} lateStartLocalDate=${lateStartLocalDate}`);


### PR DESCRIPTION
…one + state filter

- sendAutoCancelUnshipped.js: drop the Monday +24h grace. Combined with the 12h scan-lag grace it delayed Mon-start auto-cancels to Wed noon (too generous). Mon-start now treated like any other day → deadline Mon 23:59:59 PT, scan-lag +12h → fires Tue ~noon PT.
- sendAutoCancelUnshipped.js: replace silently-ignored state: 'accepted' filter with lastTransitions (same fix as shipping-reminders).
- sendReturnReminders.js: dueLocalDate now reads the UTC calendar date of booking.end for end-exclusive UTC-midnight day-bookings (Sharetribe default). Previously bookingEndPT.format() converted to PT first and yielded the day-before, making T-1 fire one day early (observed on tx 6a1a2b0e-bb16-440c-b944-34b339b5cf8c: booking.end Wed Jun 3, T-1 fired Mon Jun 1 instead of Tue Jun 2).