### PR TITLE
fix(sms-cron): tighten Mon-start auto-cancel + fix return T-1 & 8-SMS…

### DIFF
--- a/server/scripts/sendReturnReminders.js
+++ b/server/scripts/sendReturnReminders.js
@@ -642,7 +642,12 @@ async function sendReturnReminders(allowExitOnError = true) {
             continue;
           }
 
-          const returnDayLocalDate = bookingEndPT ? bookingEndPT.format('YYYY-MM-DD') : null;
+          // Use the same dueLocalDate derived above (UTC-date for UTC-midnight
+          // day-bookings). Previously this re-derived from bookingEndPT, which
+          // for end-exclusive UTC-midnight bookings resolves to the PT-day BEFORE
+          // the actual return ship day and made the day-of 8-SMS silently never
+          // fire for every Sharetribe day-booking.
+          const returnDayLocalDate = dueLocalDate;
           const sendAtPT = returnDayLocalDate
             ? dayjs.tz(
                 `${returnDayLocalDate} ${String(SEND_HOUR_PT).padStart(2, '0')}:${String(SEND_MINUTE_PT).padStart(2, '0')}:00`,


### PR DESCRIPTION
… for UTC-midnight bookings + state filter

- sendAutoCancelUnshipped.js: drop the Monday +24h grace in getCancelDeadline. Mon-start now treated like any other day — deadline Mon 23:59:59 PT, scan-lag +12h → fires Tue ~noon PT.
- sendAutoCancelUnshipped.js: replace silently-ignored state: 'accepted' filter with lastTransitions (same fix as shipping-reminders).
- sendReturnReminders.js: dueLocalDate now reads booking.end's UTC calendar date for end-exclusive UTC-midnight day-bookings. Previously bookingEndPT.format() converted to PT first and yielded the day-before, making T-1 fire one day early (observed on tx 6a1a2b0e: booking.end Wed Jun 3, T-1 fired Mon Jun 1 instead of Tue Jun 2).
- sendReturnReminders.js: line 645 now uses the same dueLocalDate for the day-of 8-SMS branch. Previous bookingEndPT.format() there meant the 8-SMS silently never fired for any UTC-midnight day-booking (= every Sharetribe day-booking).