### PR TITLE
fix(web): read & preserve availability-plan/day plans

### DIFF
--- a/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPanel.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPanel.js
@@ -197,24 +197,27 @@ const EditListingAvailabilityPanel = props => {
 
   const isPublished = listing?.id && listingAttributes?.state !== LISTING_STATE_DRAFT;
 
-  // Helper to generate a 24/7 plan for all days of the week
-  const getAllDaysAlwaysAvailable = (timezone) => {
+  // Default "every day, one seat" plan. Sherbrt's marketplace is configured
+  // for Daily + oneSeat bookings, and Sharetribe rejects `availability-plan/time`
+  // on day-unit listings as "Invalid value" (HTTP 400). We must use
+  // `availability-plan/day` with `{ dayOfWeek, seats }` entries only —
+  // no startTime/endTime, no timezone (the latter is rejected as
+  // "Disallowed key" on day-plans). This matches what the mobile wizard
+  // writes; see sherbrt-mobile/app/lending/new/availability.tsx.
+  const getAllDaysAlwaysAvailable = () => {
     // Use the same weekday keys as in generators.js
     const WEEKDAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
     return {
-      type: 'availability-plan/time',
-      timezone: timezone || defaultTimeZone(),
+      type: 'availability-plan/day',
       entries: WEEKDAYS.map(dayOfWeek => ({
         dayOfWeek,
-        startTime: '00:00',
-        endTime: '24:00',
         seats: 1,
       })),
     };
   };
 
-  // Use the new 24/7 plan for all listings by default
-  const defaultAvailabilityPlan = getAllDaysAlwaysAvailable(defaultTimeZone());
+  // Use the day-shape plan for all listings by default
+  const defaultAvailabilityPlan = getAllDaysAlwaysAvailable();
   const availabilityPlan = listingAttributes?.availabilityPlan || defaultAvailabilityPlan;
 
   // Debug: Log the availability plan and listing state
@@ -351,21 +354,14 @@ const EditListingAvailabilityPanel = props => {
     setNextTabError(null);
     setIsNextTabInProgress(true);
     try {
-      // Create the availability data payload - allow empty plan and exceptions
+      // Preserve the listing's existing plan shape. Sherbrt's marketplace is
+      // configured for Daily + oneSeat — the Sharetribe API rejects
+      // `availability-plan/time` writes on day-unit listings with HTTP 400
+      // ("Invalid value"). Only seed a default day-shape plan when the listing
+      // genuinely has no plan yet (mobile-created listings already have one).
       const availabilityData = {
-        availabilityPlan: listing?.attributes?.availabilityPlan || {
-          type: 'availability-plan/time',
-          timezone: 'Etc/UTC',
-          entries: [
-            { dayOfWeek: 'mon', startTime: '00:00', endTime: '24:00', seats: 1 },
-            { dayOfWeek: 'tue', startTime: '00:00', endTime: '24:00', seats: 1 },
-            { dayOfWeek: 'wed', startTime: '00:00', endTime: '24:00', seats: 1 },
-            { dayOfWeek: 'thu', startTime: '00:00', endTime: '24:00', seats: 1 },
-            { dayOfWeek: 'fri', startTime: '00:00', endTime: '24:00', seats: 1 },
-            { dayOfWeek: 'sat', startTime: '00:00', endTime: '24:00', seats: 1 },
-            { dayOfWeek: 'sun', startTime: '00:00', endTime: '24:00', seats: 1 },
-          ]
-        },
+        availabilityPlan:
+          listing?.attributes?.availabilityPlan || getAllDaysAlwaysAvailable(),
         exceptions: allExceptions || []
       };
       console.log("🟠 [DEBUG] About to call onNextTab with:", availabilityData);

--- a/src/util/generators.js
+++ b/src/util/generators.js
@@ -321,9 +321,23 @@ const getEndTimeAsDate = (date, endTime, timeZone) =>
  * @param {String} timeZone IANA time zone key (e.g. "Europe/Helsinki")
  * @returns object literal like { start, end, seats } or null
  */
+// `availability-plan/day` entries are { dayOfWeek, seats } with no
+// startTime/endTime. Treat those as covering the whole local day —
+// [dayStart, nextDayStart) — so a day-shape plan ("every Mon: seats 1")
+// is interpreted as "available all day Monday." Sherbrt's marketplace is
+// configured for day-unit bookings and the mobile wizard saves plans in
+// this shape; without this branch the calendar shows every day as
+// "Not available". See sherbrt-mobile/CLAUDE_CONTEXT.md gotchas section.
+const isDayShapeEntry = e => e && (e.startTime == null || e.endTime == null);
+
 const findNextPlanEntryInfo = (date, dayEntries, timeZone) => {
   const dateInMillis = getMillis(date);
   const entry = dayEntries.find(e => {
+    if (isDayShapeEntry(e)) {
+      const dayStart = getMillis(getStartOf(date, 'day', timeZone));
+      const dayEnd = getMillis(getStartOf(date, 'day', timeZone, 1, 'days'));
+      return (dayStart <= dateInMillis && dateInMillis < dayEnd) || dayStart > dateInMillis;
+    }
     const start = getMillis(parseLocalizedTime(date, e.startTime, timeZone));
     const end = getMillis(getEndTimeAsDate(date, e.endTime, timeZone));
     // is inside entry or entry is after given date moment
@@ -331,6 +345,11 @@ const findNextPlanEntryInfo = (date, dayEntries, timeZone) => {
   });
 
   if (entry) {
+    if (isDayShapeEntry(entry)) {
+      const start = getStartOf(date, 'day', timeZone);
+      const end = getStartOf(date, 'day', timeZone, 1, 'days');
+      return { start, end, seats: entry.seats };
+    }
     const start = parseLocalizedTime(date, entry.startTime, timeZone);
     const end = getEndTimeAsDate(date, entry.endTime, timeZone);
     return { start, end, seats: entry.seats };


### PR DESCRIPTION
Sherbrt's marketplace is configured for Daily + oneSeat bookings, so Sharetribe expects `availability-plan/day` with { dayOfWeek, seats } entries only. The web wizard was forked from the stock Sharetribe template that assumes `availability-plan/time` everywhere, so:

  * MonthlyCalendar misread mobile-saved day-shape plans as having no matching entries, painting every cell 'Not available'.
  * EditListingAvailabilityPanel.handleNextTab POST-ed a time-shape plan on Save & continue, which Sharetribe rejects with HTTP 400 on day-unit listings.

Fixes:

  * src/util/generators.js findNextPlanEntryInfo: treat entries with no startTime/endTime as covering [dayStart, nextDayStart) in the listing TZ — so day-shape plans render as 'available all day'.
  * EditListingAvailabilityPanel.getAllDaysAlwaysAvailable: emit a day-shape default (no startTime/endTime, no timezone) instead of the previous time-shape default.
  * EditListingAvailabilityPanel.handleNextTab: preserve the listing's existing plan instead of overwriting it with a hard-coded time-shape payload. Only seed the day-shape default when the listing has no plan yet.

Result: a single listing's availability is now consistent across web and mobile, and Save & continue no longer 400s for mobile-touched listings.