### PR TITLE
fix(web): align availability TZ fallbacks; nullsafe ListingPageCarousel

### DIFF
--- a/src/components/OrderPanel/OrderPanel.js
+++ b/src/components/OrderPanel/OrderPanel.js
@@ -24,6 +24,7 @@ import {
 import { formatMoney } from '../../util/currency';
 import { parse, stringify } from '../../util/urlHelpers';
 import { userDisplayNameAsString } from '../../util/data';
+import { getDefaultTimeZoneOnBrowser } from '../../util/dates';
 import {
   INQUIRY_PROCESS_NAME,
   getSupportedProcessesInfo,
@@ -264,7 +265,12 @@ const OrderPanel = props => {
     );
   };
 
-  const timeZone = listing?.attributes?.availabilityPlan?.timezone || 'Etc/UTC';
+  // Day-shape plans (Sherbrt's marketplace default) carry no `timezone` key.
+  // The Round 2 duck/fetch layer falls back to browser TZ; this render/day-
+  // block layer MUST use the same fallback or fetch and render disagree by
+  // the user's UTC offset (off-by-one blocked/bookable day for US users).
+  const timeZone =
+    listing?.attributes?.availabilityPlan?.timezone || getDefaultTimeZoneOnBrowser();
   const isClosed = listing?.attributes?.state === LISTING_STATE_CLOSED;
   const isBooking = isBookingProcess(processName);
 

--- a/src/containers/EditListingPage/EditListingPage.duck.js
+++ b/src/containers/EditListingPage/EditListingPage.duck.js
@@ -971,16 +971,16 @@ export const requestFetchAvailabilityExceptions = params => (dispatch, getState,
 // Helper function for loadData call.
 const fetchLoadDataExceptions = (dispatch, listing, search, firstDayOfWeek) => {
   const hasWindow = typeof window !== 'undefined';
-  // Listing could be ownListing entity too, so we just check if attributes key exists
-  const hasTimeZone = listing?.attributes?.availabilityPlan?.timezone;
 
-  // Fetch time-zones on client side only.
-  // Note: listing needs to have time zone set!
-  if (hasWindow && listing.id && hasTimeZone) {
+  // Fetch on client side only. Sherbrt's marketplace uses
+  // `availability-plan/day` plans which Sharetribe forbids carrying a
+  // `timezone` key — so we can't gate on plan.timezone here. Fall back to
+  // the browser timezone for the query-boundary math; the exception fetch
+  // itself uses UTC dates and isn't sensitive to this fallback.
+  if (hasWindow && listing.id) {
     const listingId = listing.id;
-    // If the listing doesn't have availabilityPlan yet
-    // use the defaul timezone
-    const timezone = listing.attributes.availabilityPlan?.timezone || getDefaultTimeZoneOnBrowser();
+    const timezone =
+      listing?.attributes?.availabilityPlan?.timezone || getDefaultTimeZoneOnBrowser();
     const todayInListingsTZ = getStartOf(new Date(), 'day', timezone);
 
     const locationSearch = parse(search);

--- a/src/containers/ListingPage/ListingPage.duck.js
+++ b/src/containers/ListingPage/ListingPage.duck.js
@@ -10,6 +10,7 @@ import { denormalisedResponseEntities } from '../../util/data';
 import {
   bookingTimeUnits,
   findNextBoundary,
+  getDefaultTimeZoneOnBrowser,
   getStartOf,
   monthIdString,
   stringifyDateToISO8601,
@@ -547,28 +548,31 @@ export const sendInquiry = (listing, message) => (dispatch, getState, sdk) => {
     });
 };
 
-// Helper function to ensure listing has a proper availability plan
+// Helper function to ensure listing has a proper availability plan.
+// Sherbrt's marketplace is configured for Daily + oneSeat, so the default
+// shape is `availability-plan/day` with `{ dayOfWeek, seats }` entries only
+// (no startTime/endTime, no timezone — Sharetribe rejects the timezone key
+// on day-plans for this marketplace). This is the same shape the mobile
+// wizard writes.
 const ensureAvailabilityPlan = (listing) => {
-  const { availabilityPlan, publicData } = listing?.attributes || {};
-  
-  // If no availability plan exists, create a default 24/7 plan
+  const { availabilityPlan } = listing?.attributes || {};
+
   if (!availabilityPlan || !availabilityPlan.type) {
-    console.log('⚠️ [ListingPage.duck] No availability plan found, creating default 24/7 plan');
+    console.log('⚠️ [ListingPage.duck] No availability plan found, creating day-shape default');
     return {
-      type: 'availability-plan/time',
-      timezone: 'Etc/UTC',
+      type: 'availability-plan/day',
       entries: [
-        { dayOfWeek: 'mon', startTime: '00:00', endTime: '24:00', seats: 1 },
-        { dayOfWeek: 'tue', startTime: '00:00', endTime: '24:00', seats: 1 },
-        { dayOfWeek: 'wed', startTime: '00:00', endTime: '24:00', seats: 1 },
-        { dayOfWeek: 'thu', startTime: '00:00', endTime: '24:00', seats: 1 },
-        { dayOfWeek: 'fri', startTime: '00:00', endTime: '24:00', seats: 1 },
-        { dayOfWeek: 'sat', startTime: '00:00', endTime: '24:00', seats: 1 },
-        { dayOfWeek: 'sun', startTime: '00:00', endTime: '24:00', seats: 1 },
+        { dayOfWeek: 'mon', seats: 1 },
+        { dayOfWeek: 'tue', seats: 1 },
+        { dayOfWeek: 'wed', seats: 1 },
+        { dayOfWeek: 'thu', seats: 1 },
+        { dayOfWeek: 'fri', seats: 1 },
+        { dayOfWeek: 'sat', seats: 1 },
+        { dayOfWeek: 'sun', seats: 1 },
       ],
     };
   }
-  
+
   return availabilityPlan;
 };
 
@@ -580,7 +584,13 @@ const fetchMonthlyTimeSlots = (dispatch, listing) => {
   
   // Ensure listing has a proper availability plan
   const availabilityPlan = ensureAvailabilityPlan(listing);
-  const tz = availabilityPlan?.timezone;
+  // Day-shape plans (Sherbrt's marketplace default) don't carry a
+  // `timezone` key — Sharetribe rejects it on day-plans. Fall back to the
+  // browser TZ for query-boundary math; the timeslots query itself sends
+  // absolute Date instances and isn't sensitive to this fallback.
+  const tz =
+    availabilityPlan?.timezone ||
+    (typeof window !== 'undefined' ? getDefaultTimeZoneOnBrowser() : 'Etc/UTC');
 
   // Debug logging for availability plan
   console.log('📦 [ListingPage.duck] AvailabilityPlan on listing:', {
@@ -592,8 +602,11 @@ const fetchMonthlyTimeSlots = (dispatch, listing) => {
     publicData: publicData,
   });
 
-  // Fetch time-zones on client side only.
-  if (hasWindow && listing.id && !!tz) {
+  // Fetch on client side only. We no longer gate on `tz` directly — the
+  // fallback above guarantees we always have one. Day-shape listings would
+  // otherwise be silently skipped (no timeslot fetch → calendar shows the
+  // entire month as unavailable on the public listing page).
+  if (hasWindow && listing.id) {
     const { unitType, priceVariants, startTimeInterval } = publicData || {};
     const now = new Date();
     const startOfToday = getStartOf(now, 'day', tz);

--- a/src/containers/ListingPage/ListingPageCarousel.js
+++ b/src/containers/ListingPage/ListingPageCarousel.js
@@ -34,6 +34,7 @@ import {
   userDisplayNameAsString,
 } from '../../util/data';
 import { richText } from '../../util/richText';
+import { getDefaultTimeZoneOnBrowser } from '../../util/dates';
 import {
   isBookingProcess,
   isPurchaseProcess,
@@ -164,7 +165,13 @@ useEffect(() => {
 
     const start = new Date(year, month, 1);
     const end = new Date(year, month + 1, 0);
-    const timeZone = currentListing.attributes.availabilityPlan.timezone || 'Etc/UTC';
+    // Listings without an `availabilityPlan` (drafts, or any listing whose
+    // plan was never persisted) would TypeError on this line under the old
+    // non-optional access. Day-shape plans (Sherbrt's marketplace default)
+    // also have no `timezone` key, so we fall back to browser TZ — the same
+    // fallback the duck/fetch layer uses, to keep fetch and render aligned.
+    const timeZone =
+      currentListing?.attributes?.availabilityPlan?.timezone || getDefaultTimeZoneOnBrowser();
 
     console.log('🚀 Fetching time slots on mount:', {
       listingId: currentListing.id.uuid,


### PR DESCRIPTION
Round 2 of the availability-plan/day shape fixes. Same root cause as Round 1: web code paths assume a plan-side timezone, but Sherbrt's day-unit marketplace forbids the timezone key on day-plans, so every mobile-written listing trips a fallback.

  * EditListingPage.duck.js fetchLoadDataExceptions: no longer early-returns when plan has no timezone. Falls back to browser TZ for query-boundary math. Fixes lender's edit calendar showing no exceptions for mobile-touched listings.

  * ListingPage.duck.js fetchMonthlyTimeSlots: no longer gates on !!tz; ensureAvailabilityPlan now seeds a day-shape default. Fixes public/guest listing page showing the whole month unavailable.

  * OrderPanel.js: render/day-block layer TZ fallback now matches the duck/fetch layer (getDefaultTimeZoneOnBrowser instead of Etc/UTC). Without this, fetch and render disagree by the user's UTC offset -> off-by-one blocked/bookable day for US borrowers. Caught by the post-Round-1 audit.

  * ListingPageCarousel.js: optional-chained the availabilityPlan access so listings without a plan don't TypeError. Aligned its fallback with the rest.