### PR TITLE
fix(web): standardize availability TZ on America/Los_Angeles

### DIFF
--- a/src/components/OrderPanel/OrderPanel.js
+++ b/src/components/OrderPanel/OrderPanel.js
@@ -24,7 +24,7 @@ import {
 import { formatMoney } from '../../util/currency';
 import { parse, stringify } from '../../util/urlHelpers';
 import { userDisplayNameAsString } from '../../util/data';
-import { getDefaultTimeZoneOnBrowser } from '../../util/dates';
+import { MARKETPLACE_TZ } from '../../util/dates';
 import {
   INQUIRY_PROCESS_NAME,
   getSupportedProcessesInfo,
@@ -266,11 +266,11 @@ const OrderPanel = props => {
   };
 
   // Day-shape plans (Sherbrt's marketplace default) carry no `timezone` key.
-  // The Round 2 duck/fetch layer falls back to browser TZ; this render/day-
-  // block layer MUST use the same fallback or fetch and render disagree by
-  // the user's UTC offset (off-by-one blocked/bookable day for US users).
+  // Fall back to MARKETPLACE_TZ so fetch (ducks) and render (this layer)
+  // share one calendar-day basis — otherwise they'd disagree by the user's
+  // UTC offset and produce off-by-one bookable cells.
   const timeZone =
-    listing?.attributes?.availabilityPlan?.timezone || getDefaultTimeZoneOnBrowser();
+    listing?.attributes?.availabilityPlan?.timezone || MARKETPLACE_TZ;
   const isClosed = listing?.attributes?.state === LISTING_STATE_CLOSED;
   const isBooking = isBookingProcess(processName);
 

--- a/src/containers/EditListingPage/EditListingPage.duck.js
+++ b/src/containers/EditListingPage/EditListingPage.duck.js
@@ -3,7 +3,7 @@ import omit from 'lodash/omit';
 import { types as sdkTypes, createImageVariantConfig } from '../../util/sdkLoader';
 import { denormalisedResponseEntities } from '../../util/data';
 import {
-  getDefaultTimeZoneOnBrowser,
+  MARKETPLACE_TZ,
   getStartOf,
   getStartOfWeek,
   monthIdString,
@@ -975,12 +975,12 @@ const fetchLoadDataExceptions = (dispatch, listing, search, firstDayOfWeek) => {
   // Fetch on client side only. Sherbrt's marketplace uses
   // `availability-plan/day` plans which Sharetribe forbids carrying a
   // `timezone` key — so we can't gate on plan.timezone here. Fall back to
-  // the browser timezone for the query-boundary math; the exception fetch
-  // itself uses UTC dates and isn't sensitive to this fallback.
+  // MARKETPLACE_TZ (the canonical marketplace-wide timezone) so every
+  // reader uses the same calendar-day boundaries.
   if (hasWindow && listing.id) {
     const listingId = listing.id;
     const timezone =
-      listing?.attributes?.availabilityPlan?.timezone || getDefaultTimeZoneOnBrowser();
+      listing?.attributes?.availabilityPlan?.timezone || MARKETPLACE_TZ;
     const todayInListingsTZ = getStartOf(new Date(), 'day', timezone);
 
     const locationSearch = parse(search);

--- a/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPanel.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPanel.js
@@ -4,7 +4,11 @@ import classNames from 'classnames';
 
 // Import configs and util modules
 import { FormattedMessage } from '../../../../util/reactIntl';
-import { getDefaultTimeZoneOnBrowser, timestampToDate } from '../../../../util/dates';
+import {
+  MARKETPLACE_TZ,
+  marketplaceDayStart,
+  timestampToDate,
+} from '../../../../util/dates';
 import { AVAILABILITY_MULTIPLE_SEATS, LISTING_STATE_DRAFT } from '../../../../util/types';
 import { DAY, isFullDay } from '../../../../transactions/transaction';
 
@@ -12,92 +16,16 @@ import { DAY, isFullDay } from '../../../../transactions/transaction';
 import { Button, H3, InlineTextButton, ListingLink, Modal, Form } from '../../../../components';
 
 // Import modules from this directory
-import EditListingAvailabilityPlanForm from './EditListingAvailabilityPlanForm';
 import EditListingAvailabilityExceptionForm from './EditListingAvailabilityExceptionForm';
 import MonthlyCalendar from './MonthlyCalendar/MonthlyCalendar';
 
 import css from './EditListingAvailabilityPanel.module.css';
 
-// This is the order of days as JavaScript understands them
-// The number returned by "new Date().getDay()" refers to day of week starting from sunday.
-const WEEKDAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
-
-// This is the order of days as JavaScript understands them
-// The number returned by "new Date().getDay()" refers to day of week starting from sunday.
-const rotateDays = (days, startOfWeek) => {
-  return startOfWeek === 0 ? days : days.slice(startOfWeek).concat(days.slice(0, startOfWeek));
-};
-
-const defaultTimeZone = () =>
-  typeof window !== 'undefined' ? getDefaultTimeZoneOnBrowser() : 'Etc/UTC';
-
-///////////////////////////////////////////////////
-// EditListingAvailabilityExceptionPanel - utils //
-///////////////////////////////////////////////////
-
-// Create initial entry mapping for form's initial values
-const createEntryDayGroups = (entries = {}) => {
-  // Collect info about which days are active in the availability plan form:
-  let activePlanDays = [];
-  return entries.reduce((groupedEntries, entry) => {
-    const { startTime, endTime: endHour, dayOfWeek, seats } = entry;
-    const dayGroup = groupedEntries[dayOfWeek] || [];
-    activePlanDays = activePlanDays.includes(dayOfWeek)
-      ? activePlanDays
-      : [...activePlanDays, dayOfWeek];
-    return {
-      ...groupedEntries,
-      [dayOfWeek]: [
-        ...dayGroup,
-        {
-          startTime,
-          endTime: endHour === '00:00' ? '24:00' : endHour,
-          seats,
-        },
-      ],
-      activePlanDays,
-    };
-  }, {});
-};
-
-// Create initial values for the availability plan
-const createInitialPlanValues = availabilityPlan => {
-  const { timezone, entries } = availabilityPlan || {};
-  const tz = timezone || defaultTimeZone();
-  return {
-    timezone: tz,
-    ...createEntryDayGroups(entries),
-  };
-};
-
-// Create entries from submit values
-const createEntriesFromSubmitValues = values =>
-  WEEKDAYS.reduce((allEntries, dayOfWeek) => {
-    const dayValues = values[dayOfWeek] || [];
-    const dayEntries = dayValues.map(dayValue => {
-      const { startTime, endTime, seats } = dayValue;
-      // Note: This template doesn't support seats yet.
-      return startTime && endTime
-        ? {
-            dayOfWeek,
-            seats: seats ?? 1,
-            startTime,
-            endTime: endTime === '24:00' ? '00:00' : endTime,
-          }
-        : null;
-    });
-
-    return allEntries.concat(dayEntries.filter(e => !!e));
-  }, []);
-
-// Create availabilityPlan from submit values
-const createAvailabilityPlan = values => ({
-  availabilityPlan: {
-    type: 'availability-plan/time',
-    timezone: values.timezone,
-    entries: createEntriesFromSubmitValues(values),
-  },
-});
+// Note: the legacy `availability-plan/time` editor (createEntryDayGroups,
+// createInitialPlanValues, createEntriesFromSubmitValues, createAvailabilityPlan,
+// handlePlanSubmit) was removed in the TZ-basis cleanup. Sherbrt is a Daily +
+// oneSeat marketplace, and the plan-shape contract is `availability-plan/day`
+// — set once in handleNextTab below and otherwise immutable on this panel.
 
 //////////////////////////////////
 // EditListingAvailabilityPanel //
@@ -179,7 +107,6 @@ const EditListingAvailabilityPanel = props => {
   } = props;
   // Hooks
   const [isEditExceptionsModalOpen, setIsEditExceptionsModalOpen] = useState(false);
-  const [valuesFromLastSubmit, setValuesFromLastSubmit] = useState(null);
   const [nextTabError, setNextTabError] = useState(null);
   const [isNextTabInProgress, setIsNextTabInProgress] = useState(false);
 
@@ -231,32 +158,41 @@ const EditListingAvailabilityPanel = props => {
     allExceptions: allExceptions,
   });
 
-  // CRITICAL FIX: Utility function to format dates as UTC midnight ISO strings
-  const formatDateToUtcMidnight = (dateObj) => {
+  // Normalize an incoming start/end date to MARKETPLACE_TZ midnight, returned
+  // as an ISO 8601 string the SDK can parse. Accepts either:
+  //   * a JS Date with browser-local YMD components (from FieldDateRangeInput
+  //     in the exception modal), or
+  //   * an ISO 8601 string whose `YYYY-MM-DD` prefix represents the lender's
+  //     intended calendar day (from MonthlyCalendar's tap handler, which
+  //     already builds an LA-midnight ISO).
+  // Anchoring to MARKETPLACE_TZ (instead of UTC midnight, the previous
+  // anchor) means "July 4 blocked" stores the same UTC interval whether the
+  // lender clicked it on web or mobile. See src/util/dates.js MARKETPLACE_TZ.
+  const formatDateToMarketplaceDayStart = (dateObj) => {
     if (!dateObj) return null;
-    
-    // If it's already a string in the correct format, return it
-    if (typeof dateObj === 'string' && dateObj.includes('T00:00:00.000Z')) {
-      return dateObj;
-    }
-    
-    // If it's a string but not in the correct format, parse it
-    if (typeof dateObj === 'string') {
-      const date = new Date(dateObj);
-      if (isNaN(date.getTime())) {
-        console.error('Invalid date string:', dateObj);
+
+    if (dateObj instanceof Date) {
+      if (isNaN(dateObj.getTime())) {
+        console.error('Invalid Date:', dateObj);
         return null;
       }
-      const dateStr = date.toISOString().split('T')[0]; // Get YYYY-MM-DD
-      return `${dateStr}T00:00:00.000Z`;
+      return marketplaceDayStart(
+        dateObj.getFullYear(),
+        dateObj.getMonth(),
+        dateObj.getDate()
+      ).toISOString();
     }
-    
-    // If it's a Date object
-    if (dateObj instanceof Date) {
-      const dateStr = dateObj.toISOString().split('T')[0]; // Get YYYY-MM-DD
-      return `${dateStr}T00:00:00.000Z`;
+
+    if (typeof dateObj === 'string') {
+      const dateOnly = dateObj.split('T')[0];
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(dateOnly)) {
+        console.error('Invalid date string (expected YYYY-MM-DD or ISO):', dateObj);
+        return null;
+      }
+      const [y, m, d] = dateOnly.split('-').map(Number);
+      return marketplaceDayStart(y, m - 1, d).toISOString();
     }
-    
+
     console.error('Invalid date object:', dateObj);
     return null;
   };
@@ -272,8 +208,8 @@ const EditListingAvailabilityPanel = props => {
       // Ensure listingId is a string UUID (not a Sharetribe UUID object)
       const listingId = typeof listing.id === 'string' ? listing.id : listing.id.uuid;
       // Ensure start/end are properly formatted UTC midnight ISO strings
-      const startISO = formatDateToUtcMidnight(start);
-      const endISO = formatDateToUtcMidnight(end);
+      const startISO = formatDateToMarketplaceDayStart(start);
+      const endISO = formatDateToMarketplaceDayStart(end);
 
       console.log('🧪 [DEBUG] Processed values:', { listingId, startISO, endISO, seats });
       console.log('🧪 [DEBUG] Original start/end types:', { 
@@ -386,40 +322,6 @@ const EditListingAvailabilityPanel = props => {
     isNextTabInProgress,
     nextTabError
   });
-  const initialPlanValues = valuesFromLastSubmit
-    ? valuesFromLastSubmit
-    : createInitialPlanValues(availabilityPlan);
-
-  const handlePlanSubmit = values => {
-    setValuesFromLastSubmit(values);
-
-    // Get existing publicData to preserve retailPrice and other fields
-    const existingPublicData = listing?.attributes?.publicData || {};
-    
-    // Create availability plan data
-    const availabilityPlanData = createAvailabilityPlan(values);
-    
-    // Merge existing publicData with any new publicData to prevent overwriting
-    const updateValues = {
-      ...availabilityPlanData,
-      publicData: {
-        ...existingPublicData, // Preserve existing publicData including retailPrice
-        ...(availabilityPlanData.publicData || {}),
-      },
-    };
-    
-    console.debug('[EditListingAvailabilityPanel] handlePlanSubmit publicData=', updateValues.publicData);
-
-    // Final Form can wait for Promises to return.
-    return onSubmit(updateValues)
-      .then(() => {
-        // setIsEditPlanModalOpen(false); // REMOVED
-      })
-      .catch(e => {
-        // Don't close modal if there was an error
-      });
-  };
-
   const sortedAvailabilityExceptions = allExceptions;
 
   // Save exception click handler
@@ -444,8 +346,8 @@ const EditListingAvailabilityPanel = props => {
     const listingId = typeof listing.id === 'string' ? listing.id : listing.id.uuid;
     
     // CRITICAL FIX: Format dates as UTC midnight ISO strings as expected by the server
-    const startISO = formatDateToUtcMidnight(range.start);
-    const endISO = formatDateToUtcMidnight(range.end);
+    const startISO = formatDateToMarketplaceDayStart(range.start);
+    const endISO = formatDateToMarketplaceDayStart(range.end);
     
     // Validate that we have valid dates
     if (!startISO || !endISO) {
@@ -560,7 +462,7 @@ const EditListingAvailabilityPanel = props => {
                   firstDayOfWeek={firstDayOfWeek}
                   routeConfiguration={routeConfiguration}
                   history={history}
-                  timeZone={availabilityPlan.timezone}
+                  timeZone={availabilityPlan.timezone || MARKETPLACE_TZ}
                 />
               </>
             ) : null}
@@ -634,7 +536,7 @@ const EditListingAvailabilityPanel = props => {
                   fetchErrors={errors}
                   onFetchExceptions={onFetchExceptions}
                   onSubmit={saveException}
-                  timeZone={availabilityPlan.timezone}
+                  timeZone={availabilityPlan.timezone || MARKETPLACE_TZ}
                   unitType={unitType}
                   updateInProgress={updateInProgress}
                   useFullDays={useFullDays}

--- a/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/MonthlyCalendar/MonthlyCalendar.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/MonthlyCalendar/MonthlyCalendar.js
@@ -15,6 +15,7 @@ import {
 
 import {
   getStartOf,
+  marketplaceDayStart,
   parseDateFromISO8601,
   stringifyDateToISO8601,
   isSameDate,
@@ -167,9 +168,18 @@ const CalendarDay = ({
       // Add exception (make unavailable)
       console.log('🧪 [DEBUG] Adding exception for date:', date.toISOString());
       if (onAddAvailabilityException) {
-        // Use UTC midnight for start and end (next day) to avoid timezone/DST issues
-        const startDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-        const endDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate() + 1));
+        // Anchor to MARKETPLACE_TZ midnight so this exception means the same
+        // calendar day regardless of which device/coast clicked it. Using
+        // UTC midnight here used to bleed the block across two calendar days
+        // for any non-UTC viewer (Sherbrt has no UTC users). Building the
+        // end as a separate `marketplaceDayStart(y, m, d+1)` call is
+        // DST-safe — moment-tz lands on next-day midnight in the listing TZ
+        // even when the calendar day is 23 or 25 hours long.
+        const y = date.getFullYear();
+        const m = date.getMonth();
+        const d = date.getDate();
+        const startDate = marketplaceDayStart(y, m, d);
+        const endDate = marketplaceDayStart(y, m, d + 1);
         const startISO = startDate.toISOString();
         const endISO = endDate.toISOString();
         const exceptionParams = {

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsPanel.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsPanel.js
@@ -183,30 +183,26 @@ const initialValuesForListingFields = (
  */
 const setAvailabilityPlanForListing = processAlias => {
   const isBooking = isBookingProcessAlias(processAlias);
-  
+
   if (isBooking) {
     // For bookable listings, don't set availability plan during creation
     // Let the availability panel handle it later to avoid API validation issues
     return {};
-  } else {
-    // For non-bookable listings, set availability-plan to seats=0
-    return {
-      availabilityPlan: {
-        type: 'availability-plan/time',
-        timezone: 'Etc/UTC',
-        entries: [
-          // Note: "no entries" is the same as seats=0 for every entry.
-          // { dayOfWeek: 'mon', startTime: '00:00', endTime: '00:00', seats: 0 },
-          // { dayOfWeek: 'tue', startTime: '00:00', endTime: '00:00', seats: 0 },
-          // { dayOfWeek: 'wed', startTime: '00:00', endTime: '00:00', seats: 0 },
-          // { dayOfWeek: 'thu', startTime: '00:00', endTime: '00:00', seats: 0 },
-          // { dayOfWeek: 'fri', startTime: '00:00', endTime: '00:00', seats: 0 },
-          // { dayOfWeek: 'sat', startTime: '00:00', endTime: '00:00', seats: 0 },
-          // { dayOfWeek: 'sun', startTime: '00:00', endTime: '00:00', seats: 0 },
-        ],
-      },
-    };
   }
+
+  // Non-bookable listings (e.g. purchase processes): empty day-shape plan.
+  // The previous time-shape default would be rejected by Sharetribe on
+  // Sherbrt's marketplace (Daily + oneSeat config). An empty `entries`
+  // array reads as "seats:0 for every day" — the correct "not bookable
+  // by default" starting state for a purchase listing. Sherbrt has no
+  // non-booking process today, so this branch is dead — but it's now
+  // safe rather than a 400-on-first-purchase-launch landmine.
+  return {
+    availabilityPlan: {
+      type: 'availability-plan/day',
+      entries: [],
+    },
+  };
 };
 
 /**

--- a/src/containers/ListingPage/ListingPage.duck.js
+++ b/src/containers/ListingPage/ListingPage.duck.js
@@ -8,9 +8,9 @@ import * as log from '../../util/log';
 import { toUuidString } from '../../util/id';
 import { denormalisedResponseEntities } from '../../util/data';
 import {
+  MARKETPLACE_TZ,
   bookingTimeUnits,
   findNextBoundary,
-  getDefaultTimeZoneOnBrowser,
   getStartOf,
   monthIdString,
   stringifyDateToISO8601,
@@ -585,12 +585,10 @@ const fetchMonthlyTimeSlots = (dispatch, listing) => {
   // Ensure listing has a proper availability plan
   const availabilityPlan = ensureAvailabilityPlan(listing);
   // Day-shape plans (Sherbrt's marketplace default) don't carry a
-  // `timezone` key — Sharetribe rejects it on day-plans. Fall back to the
-  // browser TZ for query-boundary math; the timeslots query itself sends
-  // absolute Date instances and isn't sensitive to this fallback.
-  const tz =
-    availabilityPlan?.timezone ||
-    (typeof window !== 'undefined' ? getDefaultTimeZoneOnBrowser() : 'Etc/UTC');
+  // `timezone` key — Sharetribe rejects it on day-plans. Fall back to
+  // MARKETPLACE_TZ so every reader interprets exception intervals against
+  // the same calendar-day boundaries. See MARKETPLACE_TZ in util/dates.
+  const tz = availabilityPlan?.timezone || MARKETPLACE_TZ;
 
   // Debug logging for availability plan
   console.log('📦 [ListingPage.duck] AvailabilityPlan on listing:', {

--- a/src/containers/ListingPage/ListingPageCarousel.js
+++ b/src/containers/ListingPage/ListingPageCarousel.js
@@ -34,7 +34,7 @@ import {
   userDisplayNameAsString,
 } from '../../util/data';
 import { richText } from '../../util/richText';
-import { getDefaultTimeZoneOnBrowser } from '../../util/dates';
+import { MARKETPLACE_TZ } from '../../util/dates';
 import {
   isBookingProcess,
   isPurchaseProcess,
@@ -168,10 +168,11 @@ useEffect(() => {
     // Listings without an `availabilityPlan` (drafts, or any listing whose
     // plan was never persisted) would TypeError on this line under the old
     // non-optional access. Day-shape plans (Sherbrt's marketplace default)
-    // also have no `timezone` key, so we fall back to browser TZ — the same
-    // fallback the duck/fetch layer uses, to keep fetch and render aligned.
+    // also have no `timezone` key, so we fall back to MARKETPLACE_TZ — the
+    // same fallback every other availability code path uses, to keep
+    // fetch and render aligned on a single calendar-day basis.
     const timeZone =
-      currentListing?.attributes?.availabilityPlan?.timezone || getDefaultTimeZoneOnBrowser();
+      currentListing?.attributes?.availabilityPlan?.timezone || MARKETPLACE_TZ;
 
     console.log('🚀 Fetching time slots on mount:', {
       listingId: currentListing.id.uuid,

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -7,6 +7,40 @@ export const START_DATE = 'startDate';
 export const END_DATE = 'endDate';
 
 /**
+ * Marketplace-wide canonical timezone for availability math.
+ *
+ * Sherbrt is US-only and listings carry no plan-side `timezone` (Sharetribe
+ * rejects the key on `availability-plan/day` plans for this marketplace).
+ * To stop apps from each picking their own fallback (browser TZ on web,
+ * device-local on mobile, `Etc/UTC` in some classifiers), we anchor every
+ * availability date — exception writes, exception reads, calendar bucketing,
+ * day-gate logic — to a single fixed TZ. That makes "July 4 blocked" the
+ * same UTC interval regardless of who clicks it or where they're sitting.
+ *
+ * Picked `America/Los_Angeles` so that a US-Pacific lender's "July 4" is
+ * stored as exactly their local July 4. US-East lenders' "July 4" will be
+ * stored as PT-local July 4 (which spans most of their ET July 4 plus a
+ * sliver of ET July 5 evening), but that's the correct trade-off for
+ * Sherbrt's user mix. Re-anchor here if that mix shifts.
+ */
+export const MARKETPLACE_TZ = 'America/Los_Angeles';
+
+/**
+ * UTC `Date` representing the START of the given calendar day in
+ * `MARKETPLACE_TZ`. Pass the Y/M/D the user *clicked* (i.e. as labeled on
+ * the calendar), not a Date object whose UTC components might fall on a
+ * different YMD than the visible one. This is the right way to construct
+ * availability-exception start/end timestamps.
+ *
+ * @param {number} year e.g. 2026
+ * @param {number} month 0-indexed, like JS Date.getMonth()
+ * @param {number} day 1-indexed, like JS Date.getDate()
+ * @returns {Date} UTC instant of marketplace-TZ midnight on (year, month, day)
+ */
+export const marketplaceDayStart = (year, month, day) =>
+  moment.tz({ year, month, day }, MARKETPLACE_TZ).startOf('day').toDate();
+
+/**
  * Time unit configurations.
  * These contain custom time units as well as the time units that moment.js supports.
  */


### PR DESCRIPTION
Round 3 of the availability-shape fixes. Closes the cross-app basis split flagged by the post-Round-2 audit (findings ① + ② + ⑤ + ⑥ + ⑪).

Before: web wrote exception intervals as UTC midnight, mobile wrote them as device-local midnight, and each reader fell back to a different TZ (browser TZ in the ducks, Etc/UTC in some classifiers, device-local on mobile). Net effect: "July 4 blocked" stored as a different UTC interval depending on who clicked it and from where, and every reader re-bucketed those intervals against its own local-day boundaries. Result was an off-by-one bookable cell for any US lender.

After: a single MARKETPLACE_TZ constant (America/Los_Angeles) anchors every availability date — exception writes, exception reads, calendar bucketing, day-gate logic. The same fixed TZ both apps now read against.

  * src/util/dates.js: new MARKETPLACE_TZ constant + marketplaceDayStart helper that returns the UTC instant of marketplace-TZ midnight on a given Y/M/D (DST-safe via moment-tz).

  * MonthlyCalendar.js: tap-to-block writes intervals as [marketplaceDayStart(y,m,d), marketplaceDayStart(y,m,d+1)] instead of Date.UTC(...). Using a separate next-day call (not +24h) so DST transitions in March/November don't drift.

  * EditListingAvailabilityPanel.js: formatDateToUtcMidnight renamed to formatDateToMarketplaceDayStart and rewritten to anchor at LA midnight regardless of whether the caller hands in a Date or an already-formatted ISO string. The plan-write timeZone prop now falls back to MARKETPLACE_TZ. Removed the dead time-shape editor (createEntryDayGroups, createInitialPlanValues, createEntriesFromSubmitValues, createAvailabilityPlan, handlePlanSubmit, valuesFromLastSubmit, EditListingAvailabilityPlanForm import) — never wired up after the MonthlyCalendar migration but a 400-on-write landmine if anyone rewired it.

  * EditListingPage.duck.js + ListingPage.duck.js + OrderPanel.js + ListingPageCarousel.js: TZ fallback browser-TZ -> MARKETPLACE_TZ. Same calendar-day basis from fetch through render through tap.

  * EditListingDetailsPanel.js: non-booking else-branch returns an empty day-shape plan instead of an empty time-shape one. No-op today (Sherbrt has no non-booking process), but safe rather than a launch-day 400 if a purchase process is ever added.

Mobile alignment ships in a follow-up PR — until then mobile still writes device-local-midnight intervals, but the web read path will interpret those against MARKETPLACE_TZ which is close enough for the existing mobile-written data (most lender devices are already on a US TZ). A migration script will re-anchor stragglers.