### PR TITLE
fix(web): normalize day overflow in marketplaceDayStart

### DIFF
--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -32,13 +32,32 @@ export const MARKETPLACE_TZ = 'America/Los_Angeles';
  * different YMD than the visible one. This is the right way to construct
  * availability-exception start/end timestamps.
  *
+ * `day` may exceed the month's length (e.g. `day: 32` on a 31-day month
+ * to express "next-month-day-1") — implementation handles overflow by
+ * anchoring at `{ year, month, day: 1 }` and stepping forward via
+ * `.add('days')`. Both `moment.tz({ day: 32 })` object form and
+ * `moment.tz([y, m, 32])` array form return Invalid Date — neither
+ * normalizes overflow — so callers like `marketplaceDayStart(y, m, d+1)`
+ * (used to construct the EXCLUSIVE end of a "block this calendar day"
+ * exception) would otherwise throw on every month-end.
+ *
+ * `.add('days')` advances calendar days in the listing TZ, which is
+ * DST-safe: spring-forward and fall-back days in LA are 23 and 25 hours
+ * long, but adding one calendar day still lands on the next calendar
+ * midnight.
+ *
  * @param {number} year e.g. 2026
  * @param {number} month 0-indexed, like JS Date.getMonth()
- * @param {number} day 1-indexed, like JS Date.getDate()
- * @returns {Date} UTC instant of marketplace-TZ midnight on (year, month, day)
+ * @param {number} day 1-indexed, like JS Date.getDate(); may overflow
+ * @returns {Date} UTC instant of marketplace-TZ midnight on the
+ *   (year, month, day) calendar day, with day overflow normalized
  */
 export const marketplaceDayStart = (year, month, day) =>
-  moment.tz({ year, month, day }, MARKETPLACE_TZ).startOf('day').toDate();
+  moment
+    .tz({ year, month, day: 1 }, MARKETPLACE_TZ)
+    .startOf('day')
+    .add(day - 1, 'days')
+    .toDate();
 
 /**
  * Time unit configurations.


### PR DESCRIPTION
`moment.tz({ day: 32 })` returns Invalid Date — neither moment's object form nor array form normalizes day overflow the way `Date.UTC(y, m, 32)` does. This blocked `marketplaceDayStart(y, m, d + 1)` on every month-end: tap "block Jan 31" -> end-of-exception = Jan 32 -> Invalid Date -> `.toISOString()` throws RangeError -> the MonthlyCalendar tap handler dies without creating the exception.

Fix: anchor at `{ year, month, day: 1 }` (always valid) and step forward via `moment.add(day - 1, 'days')`. `.add('days')` advances calendar days in MARKETPLACE_TZ, which is DST-safe — spring-forward and fall-back days in LA are 23 and 25 hours long, but adding one calendar day still lands on the next calendar midnight.

Verified equivalence between web (moment.tz) and mobile (Intl-based) marketplaceDayStart implementations across the full 2025-2027 day domain (1,095 days, including both DST boundaries each year) plus all 12 month-end overflows of 2026. Zero mismatches.

Found by independent verification of PR #79 before merge.