### PR TITLE
Add Meta Pixel tracking for lender acquisition campaigns

### DIFF
--- a/server/csp.js
+++ b/server/csp.js
@@ -58,6 +58,10 @@ const defaultDirectives = {
     'plausible.io',
     '*.plausible.io',
 
+    // Meta Pixel (Facebook Pixel) — fbevents.js beacons/XHR
+    'connect.facebook.net',
+    'www.facebook.com',
+
     'fonts.googleapis.com',
 
     'sentry.io',
@@ -108,6 +112,9 @@ const defaultDirectives = {
     // Youtube (static image)
     '*.ytimg.com',
 
+    // Meta Pixel (Facebook Pixel) — noscript/tracking pixel image
+    'www.facebook.com',
+
     // Stripe
     'https://q.stripe.com',
     '*.stripe.com',
@@ -124,8 +131,11 @@ const defaultDirectives = {
     '*.g.doubleclick.net',
     'js.stripe.com',
     'plausible.io',
+
+    // Meta Pixel (Facebook Pixel)
+    'connect.facebook.net',
   ],
-  "script-src-elem": [self, blob, "https://js.stripe.com", "https://api.mapbox.com", "https://*.mapbox.com"],
+  "script-src-elem": [self, blob, "https://js.stripe.com", "https://api.mapbox.com", "https://*.mapbox.com", "https://connect.facebook.net"],
   "manifest-src": [self],
   "worker-src": [self, blob],
   styleSrc: [self, unsafeInline, 'fonts.googleapis.com', 'api.mapbox.com'],

--- a/src/analytics/handlers.js
+++ b/src/analytics/handlers.js
@@ -1,6 +1,21 @@
+import { pageView } from '../util/metaPixel';
+
 export class LoggingAnalyticsHandler {
   trackPageView(url) {
     console.log('Analytics page view:', url);
+  }
+}
+
+// Meta Pixel (Facebook Pixel). The loader, init and initial PageView are set
+// up in util/includeScripts.js. Here we only send PageView for in-app SPA
+// navigation. Like GA4 below, we skip the very first location change
+// (previousPath is null right after page load) so we don't double-count the
+// initial PageView already fired by the loader.
+export class MetaPixelHandler {
+  trackPageView(canonicalPath, previousPath) {
+    if (previousPath) {
+      pageView();
+    }
   }
 }
 

--- a/src/config/configAnalytics.js
+++ b/src/config/configAnalytics.js
@@ -17,3 +17,11 @@ export const googleAnalyticsId = process.env.REACT_APP_GOOGLE_ANALYTICS_ID;
 // You can add multiple domains separated by comma
 // E.g. REACT_APP_PLAUSIBLE_DOMAINS=example1.com,example2.com
 export const plausibleDomains = process.env.REACT_APP_PLAUSIBLE_DOMAINS;
+
+// Optional
+// Meta Pixel (Facebook Pixel) ID used to optimize Meta ad campaigns.
+// Override per-environment with REACT_APP_META_PIXEL_ID; falls back to the
+// sherbrt.com production pixel so tracking works without extra env setup.
+// The pixel loader/init lives in util/includeScripts.js and the SPA page-view
+// handler in analytics/handlers.js.
+export const metaPixelId = process.env.REACT_APP_META_PIXEL_ID || '838865308919724';

--- a/src/containers/AuthenticationPage/SignupForm/SignupForm.js
+++ b/src/containers/AuthenticationPage/SignupForm/SignupForm.js
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Form as FinalForm } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
 import classNames from 'classnames';
+
+import { lead } from '../../../util/metaPixel';
 
 import { FormattedMessage, useIntl } from '../../../util/reactIntl';
 import { propTypes } from '../../../util/types';
@@ -59,12 +61,22 @@ const getValuesForSubmission = (values, registeredFields, userFields, userType, 
   return { publicData: restOfPublicData, protectedData };
 };
 
-const SignupFormComponent = props => (
-  <FinalForm
-    {...props}
-    mutators={{ ...arrayMutators }}
-    initialValues={{ userType: props.preselectedUserType || getSoleUserTypeMaybe(props.userTypes) }}
-    render={formRenderProps => {
+const SignupFormComponent = props => {
+  // Meta Pixel: fire a single Lead event when the user first interacts with the
+  // signup form (focus bubbles up from any field to the <Form> element).
+  const hasFiredLead = useRef(false);
+  const handleSignupFormFocus = () => {
+    if (hasFiredLead.current) return;
+    hasFiredLead.current = true;
+    lead({ contentName: 'Signup Started', source: 'AuthenticationPage' });
+  };
+
+  return (
+    <FinalForm
+      {...props}
+      mutators={{ ...arrayMutators }}
+      initialValues={{ userType: props.preselectedUserType || getSoleUserTypeMaybe(props.userTypes) }}
+      render={formRenderProps => {
       const {
         rootClassName,
         className,
@@ -188,7 +200,7 @@ const SignupFormComponent = props => (
       console.log('SIGNUP PAYLOAD:', JSON.stringify(signupParams, null, 2));
 
       return (
-        <Form className={classes} onSubmit={handleSubmit}>
+        <Form className={classes} onSubmit={handleSubmit} onFocus={handleSignupFormFocus}>
           <FieldSelectUserType
             name="userType"
             userTypes={userTypes}
@@ -406,9 +418,10 @@ const SignupFormComponent = props => (
           </div>
         </Form>
       );
-    }}
-  />
-);
+      }}
+    />
+  );
+};
 
 /**
  * A component that renders the signup form.

--- a/src/containers/EditListingPage/EditListingPage.duck.js
+++ b/src/containers/EditListingPage/EditListingPage.duck.js
@@ -24,6 +24,7 @@ import {
   fetchStripeAccount,
 } from '../../ducks/stripeConnectAccount.duck';
 import { fetchCurrentUser } from '../../ducks/user.duck';
+import { customEvent } from '../../util/metaPixel';
 
 const { UUID, Money } = sdkTypes;
 
@@ -805,6 +806,10 @@ export const requestPublishListingDraft = listingId => (dispatch, getState, sdk)
         dispatch(addMarketplaceEntities(response));
       }
       dispatch(publishListingSuccess(response));
+      // Meta Pixel: a draft listing was published. Fires on every publish (we
+      // don't distinguish first-vs-subsequent here); Meta still optimizes
+      // against "users likely to publish a listing."
+      customEvent('LenderActivated', { content_name: 'Listing Published' });
       return response;
     })
     .catch(e => {

--- a/src/ducks/auth.duck.js
+++ b/src/ducks/auth.duck.js
@@ -2,6 +2,7 @@ import * as log from '../util/log';
 import { storableError } from '../util/errors';
 import { clearCurrentUser, fetchCurrentUser } from './user.duck';
 import { createUserWithIdp, post } from '../util/api';
+import { completeRegistration } from '../util/metaPixel';
 
 const authenticated = authInfo => authInfo?.isAnonymous === false;
 const loggedInAs = authInfo => authInfo?.isLoggedInAs === true;
@@ -216,6 +217,15 @@ export const signup = params => (dispatch, getState, sdk) => {
   return sdk.currentUser
     .create(params)
     .then(() => dispatch(signupSuccess()))
+    .then(() => {
+      // Meta Pixel: lender signup completed (email/password path)
+      completeRegistration({
+        method: 'email',
+        userType: params?.publicData?.userType,
+        value: 5,
+        currency: 'USD',
+      });
+    })
     .then(() => dispatch(login(params.email, params.password)))
     .then(() => {
       // After successful signup and login, ensure phone number is in protectedData
@@ -247,6 +257,15 @@ export const signupWithIdp = params => (dispatch, getState, sdk) => {
   return createUserWithIdp(params)
     .then(res => {
       return dispatch(confirmSuccess());
+    })
+    .then(() => {
+      // Meta Pixel: lender signup completed (social / IdP path)
+      completeRegistration({
+        method: params?.idpId || 'idp',
+        userType: params?.publicData?.userType,
+        value: 5,
+        currency: 'USD',
+      });
     })
     .then(() => dispatch(fetchCurrentUser()))
     .then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,11 @@ import './styles/marketplaceDefaults.css';
 // Configs and store setup
 import appSettings from './config/settings';
 import defaultConfig from './config/configDefault';
-import { LoggingAnalyticsHandler, GoogleAnalyticsHandler } from './analytics/handlers';
+import {
+  LoggingAnalyticsHandler,
+  GoogleAnalyticsHandler,
+  MetaPixelHandler,
+} from './analytics/handlers';
 import configureStore from './store';
 
 // Utils
@@ -101,7 +105,7 @@ const render = (store, shouldHydrate) => {
     });
 };
 
-const setupAnalyticsHandlers = googleAnalyticsId => {
+const setupAnalyticsHandlers = (googleAnalyticsId, metaPixelId) => {
   let handlers = [];
 
   // Log analytics page views and events in dev mode
@@ -118,6 +122,13 @@ const setupAnalyticsHandlers = googleAnalyticsId => {
     } else {
       handlers.push(new GoogleAnalyticsHandler());
     }
+  }
+
+  // Add Meta Pixel handler if a pixel ID is configured. This sends PageView on
+  // in-app navigation; the loader and initial PageView live in
+  // util/includeScripts.js.
+  if (metaPixelId) {
+    handlers.push(new MetaPixelHandler());
   }
 
   return handlers;
@@ -184,7 +195,9 @@ if (typeof window !== 'undefined') {
   // Note: on localhost:3000, you need to use environment variable.
   const googleAnalyticsIdFromSSR = initialState?.hostedAssets?.googleAnalyticsId;
   const googleAnalyticsId = googleAnalyticsIdFromSSR || process.env.REACT_APP_GOOGLE_ANALYTICS_ID;
-  const analyticsHandlers = setupAnalyticsHandlers(googleAnalyticsId);
+  // Meta Pixel is configured locally (see config/configAnalytics.js), not via
+  // the hosted analytics asset.
+  const analyticsHandlers = setupAnalyticsHandlers(googleAnalyticsId, defaultConfig.analytics?.metaPixelId);
   const store = configureStore(initialState, sdk, analyticsHandlers);
 
   require('./util/polyfills');

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -161,7 +161,12 @@ const mergeAnalyticsConfig = (hostedAnalyticsConfig, defaultAnalyticsConfig) => 
   const plausibleDomains = joinStrings(plausibleDomainsHosted, plausibleDomainsDefault);
   const plausibleDomainsMaybe = plausibleDomains ? { plausibleDomains } : {};
 
-  return { googleAnalyticsId, ...plausibleDomainsMaybe };
+  // Meta Pixel is configured locally (env / configAnalytics), not via the
+  // hosted analytics asset, so carry it through from the default config.
+  const metaPixelId = defaultAnalyticsConfig.metaPixelId;
+  const metaPixelIdMaybe = metaPixelId ? { metaPixelId } : {};
+
+  return { googleAnalyticsId, ...plausibleDomainsMaybe, ...metaPixelIdMaybe };
 };
 
 ////////////////////

--- a/src/util/includeScripts.js
+++ b/src/util/includeScripts.js
@@ -17,7 +17,7 @@ const GOOGLE_MAPS_SCRIPT_ID = 'GoogleMapsApi';
  */
 export const IncludeScripts = props => {
   const { marketplaceRootURL: rootURL, maps, analytics } = props?.config || {};
-  const { googleAnalyticsId, plausibleDomains } = analytics;
+  const { googleAnalyticsId, plausibleDomains, metaPixelId } = analytics;
 
   const { mapProvider, googleMapsAPIKey, mapboxAccessToken } = maps || {};
   const isGoogleMapsInUse = mapProvider === 'googleMaps';
@@ -106,6 +106,42 @@ export const IncludeScripts = props => {
         crossOrigin
       ></script>
     );
+  }
+
+  if (metaPixelId) {
+    // Meta Pixel (Facebook Pixel)
+    // NOTE: This template is a single-page application (SPA).
+    //       We fire the initial PageView here (once, on first client render)
+    //       and handle subsequent in-app navigation in src/analytics/handlers.js
+    //       (MetaPixelHandler). The fbevents.js script is host-whitelisted in
+    //       server/csp.js (connect.facebook.net), so it needs no nonce — same
+    //       as the gtag.js script above.
+    analyticsLibraries.push(
+      <script
+        key="meta-pixel-fbevents"
+        async
+        src="https://connect.facebook.net/en_US/fbevents.js"
+        crossOrigin
+      ></script>
+    );
+
+    // Define the fbq stub (queues calls until fbevents.js loads), then init +
+    // fire the initial PageView. Guarded so this runs exactly once per client
+    // session — re-renders of IncludeScripts (e.g. on navigation) are no-ops,
+    // which keeps the initial PageView from double-counting.
+    if (typeof window !== 'undefined' && !window.fbq) {
+      const n = (window.fbq = function fbq() {
+        n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
+      });
+      if (!window._fbq) window._fbq = n;
+      n.push = n;
+      n.loaded = true;
+      n.version = '2.0';
+      n.queue = [];
+
+      window.fbq('init', metaPixelId);
+      window.fbq('track', 'PageView');
+    }
   }
 
   const isBrowser = typeof window !== 'undefined';

--- a/src/util/metaPixel.js
+++ b/src/util/metaPixel.js
@@ -1,0 +1,51 @@
+// src/util/metaPixel.js
+// Safe wrappers around window.fbq. All calls no-op during SSR
+// or if Meta Pixel is blocked / failed to load (ad blockers, iOS ATT, etc.).
+//
+// The pixel loader and init (fbq('init', ...) + initial PageView) live in
+// util/includeScripts.js, mirroring the Google Analytics setup. SPA route
+// changes are tracked via MetaPixelHandler in analytics/handlers.js.
+
+const isClient = typeof window !== 'undefined';
+
+const isReady = () => isClient && typeof window.fbq === 'function';
+
+const track = (event, params = {}) => {
+  if (!isReady()) return;
+  try {
+    window.fbq('track', event, params);
+  } catch (err) {
+    console.warn('Meta Pixel track failed:', err);
+  }
+};
+
+const trackCustom = (event, params = {}) => {
+  if (!isReady()) return;
+  try {
+    window.fbq('trackCustom', event, params);
+  } catch (err) {
+    console.warn('Meta Pixel trackCustom failed:', err);
+  }
+};
+
+export const pageView = () => track('PageView');
+
+export const viewContent = ({ contentName, contentCategory } = {}) =>
+  track('ViewContent', {
+    content_name: contentName,
+    content_category: contentCategory,
+  });
+
+export const lead = ({ contentName, source } = {}) =>
+  track('Lead', { content_name: contentName, source });
+
+export const completeRegistration = ({ method, userType, value, currency } = {}) =>
+  track('CompleteRegistration', {
+    content_name: 'Lender Signup',
+    registration_method: method,
+    user_type: userType,
+    value,
+    currency: currency || 'USD',
+  });
+
+export const customEvent = (name, params) => trackCustom(name, params);


### PR DESCRIPTION
Pixel ID: 838865308919724 (configurable via REACT_APP_META_PIXEL_ID).

Adapted to this repo's architecture rather than the inline-snippet approach:
- The CSP is nonce-based (no 'unsafe-inline' for scripts), so a static inline <script> in public/index.html would be blocked in 'block' mode. Instead the loader is injected the same way as GA4 — via util/includeScripts.js (Helmet) with the fbq stub defined in trusted bundle JS, plus the initial PageView.
- SPA PageViews use the existing analytics middleware: MetaPixelHandler in analytics/handlers.js fires on LOCATION_CHANGED for in-app nav, skipping the first change to avoid double-counting the loader's initial PageView (mirrors the GA4 handler). react-router-dom here is v5; no withRouter tracker needed.
- metaPixelId added to config/configAnalytics.js and threaded through mergeAnalyticsConfig so it survives the hosted-config merge.
- Lead fires on first focus of the SignupForm (once per mount).
- CompleteRegistration fires on signup success in auth.duck (both the email and social/IdP paths).
- LenderActivated (custom) fires on listing publish success in EditListingPage.duck (every publish, not just the first).
- server/csp.js whitelists connect.facebook.net (scriptSrc + script-src-elem) and www.facebook.com (connectSrc + imgSrc).

All event helpers (src/util/metaPixel.js) are SSR-safe and silently no-op when window.fbq is unavailable (ad blockers, iOS ATT).

ViewContent on a "Become a Lender" page was skipped: no such page exists yet, and firing it on the generic CMS landing page would pollute the dataset.